### PR TITLE
chore: start/stop mailbox with base actor

### DIFF
--- a/internal/app/supervisor.go
+++ b/internal/app/supervisor.go
@@ -37,7 +37,8 @@ func NewSupervisor(config *config.Config) Supervisor {
 		cfg:     config,
 		mailbox: actor.NewMailbox[actormodel.Message](),
 	}
-	app.baseActor = actor.New(app)
+	app.baseActor = actor.Combine(app.mailbox, actor.New(app)).Build()
+
 	return app
 }
 
@@ -86,7 +87,6 @@ func (a *supervisor) Start() {
 			a.server.Start()
 		}
 
-		a.mailbox.Start()
 		a.started = true
 	}
 }
@@ -135,7 +135,6 @@ func (a *supervisor) SendMessageTo(receiver actormodel.MessageReceiver, ctx acto
 		if err != nil {
 			audit.Error().Err(err).Msg("Failed to send message")
 		}
-		a.mailbox.Start()
 	case actormodel.HTTPServer:
 		a.server.SendMessage(ctx, msg)
 	case actormodel.WorkflowEngine:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/gofiber/fiber/v3"
 	"github.com/open-source-cloud/fuse/internal/actormodel"
 	"github.com/open-source-cloud/fuse/internal/audit"
@@ -42,7 +43,7 @@ func NewServer(cfg config.ServerConfig, db *database.ArangoClient) Server {
 
 	sv.registerHandlers()
 
-	sv.baseActor = actor.New(sv)
+	sv.baseActor = actor.Combine(sv.mailbox, actor.New(sv)).Build()
 	return sv
 }
 
@@ -85,7 +86,6 @@ func (s *server) SendMessage(ctx actor.Context, msg actormodel.Message) {
 		audit.Error().ActorMessage(msg).Err(err).Msg("Failed to send message")
 		return
 	}
-	s.mailbox.Start()
 }
 
 func (s *server) listen() error {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -33,7 +33,7 @@ func NewEngine(supervisor actormodel.SupervisorMessenger) Engine {
 		schemas:    make(map[string]Schema),
 		workflows:  make(map[string]Workflow),
 	}
-	worker.baseActor = actor.New(worker)
+	worker.baseActor = actor.Combine(worker.mailbox, actor.New(worker)).Build()
 
 	return worker
 }
@@ -99,5 +99,4 @@ func (e *engine) SendMessage(ctx actor.Context, msg actormodel.Message) {
 	if err != nil {
 		audit.Error().ActorMessage(msg).Err(err).Msg("Failed to send message")
 	}
-	e.mailbox.Start()
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/open-source-cloud/fuse/internal/actormodel"
 	"github.com/open-source-cloud/fuse/internal/audit"
 	"github.com/open-source-cloud/fuse/internal/typeschema"
@@ -10,7 +12,6 @@ import (
 	"github.com/open-source-cloud/fuse/pkg/store"
 	"github.com/open-source-cloud/fuse/pkg/workflow"
 	"github.com/vladopajic/go-actor/actor"
-	"strings"
 )
 
 // State type for workflow states
@@ -56,7 +57,8 @@ func NewWorkflow(id string, schema Schema) Workflow {
 		state:       StateStopped,
 		currentNode: []graph.Node{},
 	}
-	worker.baseActor = actor.New(worker)
+	worker.baseActor = actor.Combine(worker.mailbox, actor.New(worker)).Build()
+
 	return worker
 }
 
@@ -95,7 +97,6 @@ func (w *workflowWorker) SendMessage(ctx Context, msg actormodel.Message) {
 			Err(err).
 			Msg("Failed to send message to Workflow")
 	}
-	w.mailbox.Start()
 }
 
 func (w *workflowWorker) handleMessage(ctx Context, msg actormodel.Message) error {


### PR DESCRIPTION
hello gents!

i was browsing and looking in dependents of `go-actor` to see how it's being used. and i just noticed slight improvement on your code base and wanted to share this PR with you.

in nutshell, `mailbox.Start()` does not need to be called with every `SendMessage`, it's much better to do it only once when starting and stopping base actor. 

in this pr, i have combined two actors (mailbox and worker) into singe actor and assigned it to baseActor so both will be started and stopped at once. 

alternatively to `Combine`, you can manually start and stop mailbox, for example in `engine.go`:
```
func (e *engine) Start() {
	e.baseActor.Start()
	e.mailbox.Start()

}
func (e *engine) Stop() {
	e.baseActor.Stop()
	e.mailbox.Stop()
}
```