### PR TITLE
feat(mux): creating mux server with ergo

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -35,7 +35,8 @@ type (
 
 	// ServerConfig http server config
 	ServerConfig struct {
-		Port string
+		Port   string `env:"SERVER_PORT" envDefault:"9090"`
+		Cookie string `env:"SERVER_COOKIE" envDefault:""`
 	}
 )
 

--- a/app/di/di.go
+++ b/app/di/di.go
@@ -34,7 +34,10 @@ var FuseAppModule = fx.Module(
 	"fuse_app",
 	fx.Provide(
 		// actors
-		actors.NewHTTPServerActorFactory,
+		actors.NewMuxServerSupFactory,
+		actors.NewMuxServerFactory,
+		actors.NewMuxServerPoolFactory,
+		actors.NewMuxWebWorkerFactory,
 		actors.NewWorkflowSupervisorFactory,
 		actors.NewWorkflowInstanceSupervisorFactory,
 		actors.NewWorkflowHandlerFactory,

--- a/internal/actors/mux_server.go
+++ b/internal/actors/mux_server.go
@@ -1,0 +1,81 @@
+package actors
+
+import (
+	"net/http"
+	"time"
+
+	"ergo.services/ergo/act"
+	"ergo.services/ergo/gen"
+	"ergo.services/ergo/meta"
+)
+
+const MuxServerName = "mux_server"
+
+type MuxServerFactory Factory[*muxServer]
+
+func NewMuxServerFactory() *MuxServerFactory {
+	return &MuxServerFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &muxServer{}
+		},
+	}
+}
+
+type muxServer struct {
+	act.Actor
+}
+
+func NewmuxServer() *muxServer {
+	return &muxServer{}
+}
+
+func (m *muxServer) Init(args ...any) error {
+	m.Log().Info("starting mux server")
+
+	mux := http.NewServeMux()
+
+	root := meta.CreateWebHandler(meta.WebHandlerOptions{
+		Worker:         MuxServerPoolName,
+		RequestTimeout: 10 * time.Second,
+	})
+
+	rootid, err := m.SpawnMeta(root, gen.MetaOptions{})
+	if err != nil {
+		m.Log().Error("unable to spawn WebHandler meta-process: %s", err)
+		return err
+	}
+
+	mux.Handle("/", root)
+	m.Log().Info("started WebHandler to serve '/' (meta-process: %s)", rootid)
+
+	// create and spawn web server meta-process
+	serverOptions := meta.WebServerOptions{
+		Port:        9090,
+		Host:        "localhost",
+		CertManager: m.Node().CertManager(),
+		Handler:     mux,
+	}
+
+	webserver, err := meta.CreateWebServer(serverOptions)
+	if err != nil {
+		m.Log().Error("unable to create Web server meta-process: %s", err)
+		return err
+	}
+
+	webserverid, err := m.SpawnMeta(webserver, gen.MetaOptions{})
+	if err != nil {
+		m.Log().Error("unable to spawn Web server meta-process: %s", err)
+		return err
+	}
+
+	https := "http"
+	if serverOptions.CertManager != nil {
+		https = "https"
+	}
+
+	m.Log().Info("started Web server %s: use %s://%s:%d/", webserverid, https, serverOptions.Host, serverOptions.Port)
+	m.Log().Info("you may check it with command below:")
+	m.Log().Info("   $ curl -k %s://%s:%d", https, serverOptions.Host, serverOptions.Port)
+
+	return nil
+}

--- a/internal/actors/mux_server_pool.go
+++ b/internal/actors/mux_server_pool.go
@@ -1,0 +1,39 @@
+package actors
+
+import (
+	"ergo.services/ergo/act"
+	"ergo.services/ergo/gen"
+)
+
+const MuxServerPoolName = "mux_server_pool"
+
+type MuxServerPoolFactory Factory[*muxServerPool]
+
+func NewMuxServerPoolFactory(muxWebWorker *MuxWebWorkerFactory) *MuxServerPoolFactory {
+	return &MuxServerPoolFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &muxServerPool{
+				muxWebWorker: muxWebWorker,
+			}
+		},
+	}
+}
+
+type muxServerPool struct {
+	act.Pool
+	muxWebWorker *MuxWebWorkerFactory
+}
+
+// Init invoked on a spawn Pool for the initializing.
+func (p *muxServerPool) Init(args ...any) (act.PoolOptions, error) {
+	p.Log().Info("starting process pool of mux http server")
+
+	opts := act.PoolOptions{
+		WorkerFactory: p.muxWebWorker.Factory,
+		PoolSize:      3,
+	}
+
+	p.Log().Info("started process pool of mux http server with %d workers", opts.PoolSize)
+
+	return opts, nil
+}

--- a/internal/actors/mux_sup.go
+++ b/internal/actors/mux_sup.go
@@ -1,0 +1,102 @@
+package actors
+
+import (
+	"ergo.services/ergo/act"
+	"ergo.services/ergo/gen"
+)
+
+const MuxServerSupName = "mux_server_sup"
+
+type MuxServerSupFactory Factory[*MuxServerSup]
+
+func NewMuxServerSupFactory(muxServerPool *MuxServerPoolFactory, muxServer *MuxServerFactory) *MuxServerSupFactory {
+	return &MuxServerSupFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &MuxServerSup{
+				muxServerPool: muxServerPool,
+				muxServer:     muxServer,
+			}
+		},
+	}
+}
+
+type MuxServerSup struct {
+	act.Supervisor
+	muxServerPool *MuxServerPoolFactory
+	muxServer     *MuxServerFactory
+}
+
+func (m *MuxServerSup) Init(args ...any) (act.SupervisorSpec, error) {
+	m.Log().Info("starting mux server supervisor")
+
+	spec := act.SupervisorSpec{
+		Type: act.SupervisorTypeSimpleOneForOne,
+		Children: []act.SupervisorChildSpec{
+			{
+				Name:    MuxServerPoolName,
+				Factory: m.muxServerPool.Factory,
+			},
+			{
+				Name:    MuxServerName,
+				Factory: m.muxServer.Factory,
+			},
+		},
+		Restart: act.SupervisorRestart{
+			Strategy:  act.SupervisorStrategyTransient,
+			Intensity: 2, // How big bursts of restarts you want to tolerate.
+			Period:    5, // In seconds.
+		},
+		EnableHandleChild:   true,
+		DisableAutoShutdown: true,
+	}
+
+	m.Log().Info("started mux server supervisor")
+
+	return spec, nil
+}
+
+//
+// Methods below are optional, so you can remove those that aren't be used
+//
+
+// HandleChildStart invoked on a successful child process starting if option EnableHandleChild
+// was enabled in act.SupervisorSpec
+func (sup *MuxServerSup) HandleChildStart(name gen.Atom, pid gen.PID) error {
+	sup.Log().Info("supervisor got child start event for %s with pid %s", name, pid)
+	return nil
+}
+
+// HandleChildTerminate invoked on a child process termination if option EnableHandleChild
+// was enabled in act.SupervisorSpec
+func (sup *MuxServerSup) HandleChildTerminate(name gen.Atom, pid gen.PID, reason error) error {
+	sup.Log().Info("supervisor got child terminate event for %s with pid %s and reason %s", name, pid, reason)
+	return nil
+}
+
+// HandleMessage invoked if Supervisor received a message sent with gen.Process.Send(...).
+// Non-nil value of the returning error will cause termination of this process.
+// To stop this process normally, return gen.TerminateReasonNormal or
+// gen.TerminateReasonShutdown. Any other - for abnormal termination.
+func (sup *MuxServerSup) HandleMessage(from gen.PID, message any) error {
+	sup.Log().Info("supervisor got message from %s", from)
+	return nil
+}
+
+// HandleCall invoked if Supervisor got a synchronous request made with gen.Process.Call(...).
+// Return nil as a result to handle this request asynchronously and
+// to provide the result later using the gen.Process.SendResponse(...) method.
+func (sup *MuxServerSup) HandleCall(from gen.PID, ref gen.Ref, request any) (any, error) {
+	sup.Log().Info("supervisor got request from %s with reference %s", from, ref)
+	return gen.Atom("pong"), nil
+}
+
+// Terminate invoked on a termination supervisor process
+func (sup *MuxServerSup) Terminate(reason error) {
+	sup.Log().Info("supervisor terminated with reason: %s", reason)
+}
+
+// HandleInspect invoked on the request made with gen.Process.Inspect(...)
+func (sup *MuxServerSup) HandleInspect(from gen.PID, item ...string) map[string]string {
+	sup.Log().Info("supervisor got inspect request from %s", from)
+	return nil
+}

--- a/internal/actors/mux_webworker.go
+++ b/internal/actors/mux_webworker.go
@@ -1,0 +1,48 @@
+package actors
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"ergo.services/ergo/act"
+	"ergo.services/ergo/gen"
+)
+
+const MuxWebWorkerName = "mux_web_worker"
+
+type MuxWebWorkerFactory Factory[*MuxWebWorker]
+
+func NewMuxWebWorkerFactory() *MuxWebWorkerFactory {
+	return &MuxWebWorkerFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &MuxWebWorker{}
+		},
+	}
+}
+
+type MuxWebWorker struct {
+	act.WebWorker
+}
+
+// Init invoked on a start this process.
+func (w *MuxWebWorker) Init(args ...any) error {
+	w.Log().Info("started WebWorker process with args %v", args)
+	return nil
+}
+
+// Handle GET requests. For the other HTTP methods (POST, PATCH, etc)
+// you need to add the accoring callback-method implementation. See act.WebWorkerBehavior.
+func (w *MuxWebWorker) HandleGet(from gen.PID, writer http.ResponseWriter, request *http.Request) error {
+	var buf bytes.Buffer
+
+	w.Log().Info("got HTTP request %q", request.URL.Path)
+	writer.Header().Set("Content-Type", "application/json")
+	// response JSON message with information about this process
+	info, _ := w.Info()
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.Encode(info)
+	writer.Write(buf.Bytes())
+	return nil
+}


### PR DESCRIPTION
# What

- Creating http server following ergo documentation (https://docs.ergo.services/meta-processes/web);
- Using mux as default web server;
- Handling http requests by a pool of webworkers managed by a supervisor;

# Why

- We want to follow the ergo documentation to manager http server and messages between processes;