### PR TITLE
Fix nil parent thread state check

### DIFF
--- a/internal/workflow/thread.go
+++ b/internal/workflow/thread.go
@@ -61,7 +61,7 @@ func (t *threads) Get(threadID uint16) *thread {
 func (t *threads) AreAllParentsFinishedFor(parentThreadIDs []uint16) bool {
 	for _, parentThreadID := range parentThreadIDs {
 		parentThread := t.Get(parentThreadID)
-		if parentThread.State() != ThreadFinished {
+		if parentThread == nil || parentThread.State() != ThreadFinished {
 			return false
 		}
 	}


### PR DESCRIPTION
Fix nil pointer dereference in `AreAllParentsFinishedFor` when parent thread is not found.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e0048e4b-757e-4c5a-8a74-20f40500d6a1) · [Cursor](https://cursor.com/background-agent?bcId=bc-e0048e4b-757e-4c5a-8a74-20f40500d6a1)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)