### PR TITLE
feat(agents): write-adr and spec-to-adr skills (W4)

### DIFF
--- a/.agents/skills/spec-to-adr/SKILL.md
+++ b/.agents/skills/spec-to-adr/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: spec-to-adr
+description: Extract the architectural decisions from a GitHub Spec Kit spec or plan and record them as ADR(s) in the project's MADR format. Use after running /speckit.specify or /speckit.plan, or when the user wants to turn a spec/plan/feature document into Architecture Decision Records.
+---
+
+# spec-to-adr
+
+Bridge the project's spec-driven workflow (GitHub Spec Kit) to its ADRs: read a spec/plan
+and capture the *decisions* it implies as ADRs. Specs describe *what* to build; ADRs record
+*why* a particular design was chosen — this skill turns the latter out of the former.
+
+This skill composes with [`write-adr`](../write-adr/SKILL.md); follow its numbering, MADR
+sections, index update, and conventions for every ADR you create.
+
+## Inputs
+
+- A Spec Kit artifact — typically `specs/<feature>/spec.md` and/or `specs/<feature>/plan.md`
+  (produced by [`.agents/commands/speckit.specify.md`](../../commands/speckit.specify.md) and
+  `speckit.plan.md`), or any feature/design doc the user points to.
+- The governing principles in [`.specify/memory/constitution.md`](../../../.specify/memory/constitution.md)
+  — decisions must not contradict it; if one does, call that out.
+
+## Steps
+
+1. **Read the spec/plan.** If the user didn't name one, list candidates
+   (`ls specs/*/spec.md specs/*/plan.md` and `.specify/`) and ask which to use.
+2. **Identify decisions.** Pull out the genuine architectural choices — not every requirement.
+   A line deserves an ADR when it (a) is costly to reverse, (b) chooses between real
+   alternatives, or (c) constrains the architecture. Examples: a storage/transport choice, a
+   new cross-cutting pattern, a dependency, a public contract. Skip pure implementation detail.
+3. **Confirm scope.** Show the user the candidate decision list and how you'd split it (one
+   ADR per decision; merge tightly-coupled ones). Let them trim before writing.
+4. **Author each ADR** via the `write-adr` conventions: next number, `docs/adr/NNNN-*.md` from
+   `docs/adr/template.md`, MADR sections, index row. In **More Information**, link back to the
+   source spec/plan (`specs/<feature>/...`) so the ADR and spec stay connected.
+5. **Set status honestly.** `Proposed` if the spec is approved but the work isn't done;
+   `Accepted` only once the decision is settled/implemented.
+
+## Notes
+
+- Reuse the spec's own "alternatives considered" / "rationale" sections as the ADR's
+  *Considered Options* and *Decision Drivers* where present — don't reinvent them.
+- One spec often yields several ADRs; keep each ADR single-decision and scannable.
+- Don't copy requirement lists into ADRs; an ADR is the *decision and its rationale*, with a
+  link to the spec for the full requirements.
+
+$ARGUMENTS

--- a/.agents/skills/write-adr/SKILL.md
+++ b/.agents/skills/write-adr/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: write-adr
+description: Author an Architecture Decision Record (ADR) in this project's MADR format under docs/adr/. Use when the user wants to record, document, or propose a significant architectural decision, says "write/add an ADR", or asks to capture the rationale for a design choice.
+---
+
+# write-adr
+
+Scaffold and author a new Architecture Decision Record in the project's MADR format.
+
+ADRs live in `docs/adr/`. The format and process are defined by:
+
+- Template: [`docs/adr/template.md`](../../../docs/adr/template.md) — the MADR 3.0 skeleton (copy this).
+- Index + process: [`docs/adr/README.md`](../../../docs/adr/README.md) — statuses, numbering, immutability.
+- Convention: [ADR-0001](../../../docs/adr/0001-record-architecture-decisions-using-madr.md).
+
+## Steps
+
+1. **Pick the next number.** Find the highest existing ADR number and add one (zero-padded, 4 digits):
+
+   ```bash
+   ls docs/adr/[0-9][0-9][0-9][0-9]-*.md | sed -E 's#.*/([0-9]{4})-.*#\1#' | sort -n | tail -1
+   ```
+
+   Next = that + 1 (e.g. `0009` → `0010`). Numbers are never reused.
+
+2. **Create the file** `docs/adr/NNNN-kebab-title.md` by copying `docs/adr/template.md`, then fill it in:
+   - `# NNNN. Title` — imperative, specific (e.g. "Use Postgres LISTEN/NOTIFY for schema replication").
+   - `Status` — `Proposed` for a decision not yet finalized/implemented; `Accepted` once it is. (`Deprecated`/`Superseded` only when retiring one.)
+   - `Date` — today's date (`YYYY-MM-DD`). Ask the user if unknown rather than guessing.
+   - **Context and Problem Statement**, **Decision Drivers**, **Considered Options** (2–4, each with honest pros/cons), **Decision Outcome** (chosen option + why), **Consequences** (good / bad / neutral), **More Information** (links to related ADRs and the code/PR it describes).
+
+3. **Ground it in the code.** Reference real file paths/types the decision touches; don't invent rationale. For a backfill ADR (documenting an existing decision), note that in a short italic line under the title and reconstruct rationale from the code and `.agents/rules/`.
+
+4. **Update the index.** Add a row to the table in `docs/adr/README.md`:
+
+   ```
+   | NNNN | [Title](NNNN-kebab-title.md) | Status | YYYY-MM-DD |
+   ```
+
+5. **Cross-link.** In the new ADR's "More Information", link related ADRs; if it supersedes one, set the old ADR's status to `Superseded by ADR-NNNN` and link forward.
+
+## Conventions
+
+- Keep each ADR ~1 page and scannable. Reserve diagrams for ADRs where they add clarity; author them in Mermaid matching the dark theme in `docs/images/`.
+- Never put secrets, keys, or tokens in an ADR.
+- ADRs are immutable once `Accepted` — to change a decision, write a new superseding ADR rather than editing the old one (fixing typos/links is fine).
+- Commit with a `docs(adr):` conventional-commit message.
+
+$ARGUMENTS


### PR DESCRIPTION
## Context

W4 of the AI-guidance program: now that `.agents/` is the portable source of truth (#71, ADR-0009), add the two ADR-authoring skills we'll use to write the foundational backfill — and that anyone can use to keep ADRs consistent.

## Skills (under `.agents/skills/`, discovered via the `.claude/skills` symlink; also available to Cursor via `.cursor/skills`)

- **`write-adr`** — scaffolds the next-numbered ADR from `docs/adr/template.md`, fills the MADR sections (grounded in real code paths, not invented rationale), and updates the `docs/adr/README.md` index. Carries `name`/`description` frontmatter so `/write-adr` is discoverable and auto-invocable.
- **`spec-to-adr`** — extracts the architectural *decisions* from a GitHub Spec Kit `spec.md`/`plan.md` and records them as ADR(s), composing with `write-adr`. Bridges the existing `speckit.*` spec-driven flow to our decision records.

Both reference `docs/adr/template.md` rather than duplicating it, and honor the ADR conventions (numbering, immutability, no secrets, `docs(adr):` commits).

## Verification

- Both reachable through `.claude/skills/{write-adr,spec-to-adr}/SKILL.md` (the discovery path) and `.cursor/skills/...`.
- Frontmatter valid (`name` + `description`); all relative links (`docs/adr/template.md`, `README.md`, `0001`, `speckit.specify.md`) resolve from the skill dirs.
- Docs/tooling only — no Go changes.

## Next

Use `write-adr` to author the **foundational backfill** ADRs `0010–0020` (themed PRs), then the **deployment-architecture** ADR (~`0021`) after reviewing `.github/workflows/` + `deploy/helm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)