### PR TITLE
docs(adr): foundational backfill + deployment architecture (0010-0021)

### DIFF
--- a/docs/adr/0010-durable-execution-journal-and-replay.md
+++ b/docs/adr/0010-durable-execution-journal-and-replay.md
@@ -1,0 +1,92 @@
+# 0010. Durable execution via an append-only journal
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+FUSE is a "Stateful Events" engine: workflows are long-running, can sleep, wait on external
+systems, fan out, and must survive process crashes and (in HA) node failures. The engine
+needs a way to make an in-flight workflow's progress durable and to resume it deterministically
+after a restart without re-running already-completed steps.
+
+## Decision Drivers
+
+- Crash/restart recovery without duplicate side effects (don't re-run completed nodes).
+- Support long-running primitives: sleep, external async, sub-workflows, ForEach.
+- Deterministic replay; auditable execution history.
+- Works with the actor model ([ADR-0002](0002-ergo-actor-model-for-workflow-execution.md)) and
+  pluggable persistence ([ADR-0003](0003-in-memory-repositories-by-default.md)).
+
+## Considered Options
+
+- **Append-only journal of every step transition + replay on recovery** (event-sourcing style).
+- **Snapshot current state periodically** and restore the latest snapshot.
+- **No durability** — keep workflow state in memory only.
+
+## Decision Outcome
+
+Chosen option: **an append-only journal**. Every transition is recorded as an immutable
+`JournalEntry` with a monotonic `Sequence` and `Timestamp` (`internal/workflow/journal.go`).
+Entry types cover the full lifecycle: `step:started|completed|failed|retrying|manual-retry`,
+`thread:created|finished`, `state:changed`, `sleep:started|completed`,
+`awakeable:created|resolved`, `subworkflow:started|completed`, and
+`foreach:started|iteration:started|iteration:completed|completed`.
+
+`Journal.Append` assigns the sequence; `NewEntries()`/`MarkPersisted()` track what has been
+flushed so `lastPersisted` avoids re-writing. On startup, `WorkflowHandler.Init` loads the
+journal (`JournalRepository.LoadAll`), `Workflow.Resume()` replays entries to rebuild threads,
+audit log, and aggregated output, identifies pending (started-but-not-completed) work, and
+returns the next `Action`. Untriggered workflows call `Trigger()` instead.
+
+Two complementary async primitives sit on top of the journal:
+- **Async function results** — a function returns `NewFunctionResultAsync()` and later calls
+  `execInfo.Finish(...)`, delivered back as an internal actor message (in-process, e.g. timer,
+  `ai/chat`). See [ADR-0005](0005-ai-agents-as-workflow-nodes-phased-roadmap.md).
+- **Awakeables** — durable promises (`internal/workflow/awakeable.go`): an `Awakeable`
+  (`ID`, `Status` pending/resolved/timed_out/cancelled, `Timeout`, `DeadlineAt`, `Result`) is
+  persisted and resolved by an **external** caller via `POST /v1/awakeables/{id}/resolve`,
+  surviving restarts. Use awakeables for external/human-in-the-loop waits; use the Finish
+  callback for in-process async.
+- **Sub-workflows** (`internal/workflow/subworkflow.go`): a `SubWorkflowRef` links parent
+  thread/exec to a child workflow; `async=false` makes the parent wait for
+  `SubWorkflowCompleted`, `async=true` lets it continue. Journaled as `subworkflow:started|completed`.
+
+### Consequences
+
+- Good: deterministic resume after crash/restart; complete audit trail; long-running primitives
+  fall out of the same mechanism.
+- Good: append-only + sequence numbers make persistence incremental and idempotent.
+- Bad: every transition is a write; the journal grows per workflow (mitigated by externalizing
+  payloads — [ADR-0019](0019-object-store-payload-externalization.md)).
+- Neutral: replay correctness depends on entries being deterministic and complete.
+
+## Pros and Cons of the Options
+
+### Append-only journal + replay
+
+- Good: full history, deterministic recovery, natural fit for sleep/await/sub-workflows.
+- Bad: more writes; replay cost grows with history length.
+
+### Periodic snapshots
+
+- Good: fast restore, less storage churn.
+- Bad: work since the last snapshot is lost or must be re-run; weaker audit trail.
+
+### In-memory only
+
+- Good: simplest, fastest.
+- Bad: any crash loses all in-flight workflows — unacceptable for a durable engine.
+
+## More Information
+
+- Code: `internal/workflow/journal.go`, `awakeable.go`, `subworkflow.go`;
+  `internal/actors/workflow_handler.go` (Init/Resume/recovery); `internal/repositories/journal.go`;
+  `internal/handlers/resolve_awakeable.go`.
+- Related: [ADR-0002](0002-ergo-actor-model-for-workflow-execution.md),
+  [ADR-0003](0003-in-memory-repositories-by-default.md),
+  [ADR-0011](0011-threading-model-and-foreach.md) (threads referenced by journal entries),
+  [ADR-0019](0019-object-store-payload-externalization.md).

--- a/docs/adr/0011-threading-model-and-foreach.md
+++ b/docs/adr/0011-threading-model-and-foreach.md
@@ -1,0 +1,81 @@
+# 0011. Thread model for fork/join and ForEach iteration
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+A workflow graph can fork into parallel branches, join them back, and loop over collections
+(ForEach). The engine needs a way to track concurrent execution paths, route async results back
+to the correct path, and know when parallel branches have all completed so a join can proceed —
+all while remaining replayable from the journal ([ADR-0010](0010-durable-execution-journal-and-replay.md)).
+
+## Decision Drivers
+
+- Represent concurrent execution paths within a single workflow instance.
+- Route a late/async result to the exact path that produced it.
+- Deterministic join semantics (a join waits for its real parents).
+- Support dynamic, runtime-sized fan-out (ForEach over N items).
+
+## Considered Options
+
+- **Per-path "threads" with IDs encoded into the execution ID**, static IDs assigned at
+  graph-compile time and dynamic IDs allocated at runtime for ForEach.
+- **Goroutine-per-branch with channels** for join coordination.
+- **A separate child workflow per branch/iteration** (reuse sub-workflows for all fan-out).
+
+## Decision Outcome
+
+Chosen option: **explicit per-path threads**. Each execution path is a `thread`
+(`internal/workflow/thread.go`) with a `uint16` id and state (running/finished). Thread ids are
+assigned by a two-phase algorithm during graph compilation (`internal/workflow/graph.go`): a
+DFS assigns ids (trigger = thread 0, a new thread per fork branch and guessed parents at joins),
+then a stabilization pass fixes each join's `parentThreads` to the real reachable parents
+(dropping "ghost" threads from cycles). A join proceeds only when all its `parentThreads` are
+finished.
+
+The **thread id is embedded in the `ExecID`** (UUIDv8, bytes 6–7, `pkg/workflow/exec_id.go`),
+so any async result — delivered later via `Finish` or an awakeable — carries the thread it
+belongs to and routes back to the correct path.
+
+**ForEach** (`internal/workflow/foreach.go` + `foreach_state.go`) builds on this with **dynamic
+thread allocation**: each iteration/batch gets a fresh thread via `threads.AllocateDynamicID()`,
+runs the loop body down the node's `each` edge, and records its result in `ForEachState`. Up to
+a configured concurrency run in parallel; when all complete, a `each → done` phase transition
+emits the aggregated `results` down the `done` edge. Merge of parallel branch outputs at a join
+uses the strategies in [ADR-0012](0012-join-merge-strategies.md).
+
+### Consequences
+
+- Good: concurrency is explicit, replayable, and addressable; async results route precisely.
+- Good: ForEach fan-out is runtime-sized without predeclaring iteration count.
+- Bad: thread ids are bounded by the 12-bit ExecID field (max 4095 concurrent threads per
+  workflow) — ample in practice but a real ceiling.
+- Neutral: the two-phase thread algorithm is non-obvious (documented in code + this ADR).
+
+## Pros and Cons of the Options
+
+### Per-path threads with ids in ExecID (chosen)
+
+- Good: precise async routing, deterministic joins, replayable, supports dynamic fan-out.
+- Bad: bespoke thread bookkeeping; 4095-thread ceiling per workflow.
+
+### Goroutine + channels per branch
+
+- Good: idiomatic Go concurrency.
+- Bad: not replayable from a journal; join/await state lives in memory and dies on restart.
+
+### Child workflow per branch/iteration
+
+- Good: reuses one mechanism; strong isolation.
+- Bad: heavy for fine-grained fan-out (a workflow instance per item); more scheduling overhead.
+
+## More Information
+
+- Code: `internal/workflow/thread.go`, `graph.go` (thread calculation), `foreach.go`,
+  `foreach_state.go`; `pkg/workflow/exec_id.go` (thread id encoding).
+- Related: [ADR-0010](0010-durable-execution-journal-and-replay.md) (journal records
+  thread:created/finished and foreach:* entries), [ADR-0012](0012-join-merge-strategies.md).

--- a/docs/adr/0012-join-merge-strategies.md
+++ b/docs/adr/0012-join-merge-strategies.md
@@ -1,0 +1,75 @@
+# 0012. Configurable merge strategies at join nodes
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+When parallel branches ([ADR-0011](0011-threading-model-and-foreach.md)) reconverge at a join
+node, their outputs must be combined into a single input for the downstream node. Different
+workflows need different semantics — collect into a list, merge into one object, take one
+branch's result, or key results by branch. A single hard-coded merge behavior would force
+awkward workarounds.
+
+## Decision Drivers
+
+- Cover the common aggregation shapes without custom code per workflow.
+- Make the behavior explicit and declarative on the node.
+- Sensible default when unspecified.
+
+## Considered Options
+
+- **A fixed set of named merge strategies** selected via node config.
+- **Always merge into one object** (single behavior).
+- **A user expression** to compute the merged value.
+
+## Decision Outcome
+
+Chosen option: **a fixed set of named strategies** configured per join node via `MergeConfig`
+(`internal/workflow/merge.go`), validated to one of: `append`, `merge`, `first`, `last`, `keyed`.
+`ApplyMergeStrategy` combines the branch outputs (each a `BranchInput` of `EdgeID`, `ThreadID`,
+`Data`):
+
+- **append** (default) — concatenate compatible slice values; otherwise collect per-key values
+  into arrays (`{count:1}+{count:2}` → `{count:[1,2]}`).
+- **merge** — shallow object merge; later branch overrides earlier on key conflicts.
+- **first** — keep only the first branch's output.
+- **last** — keep only the last branch's output.
+- **keyed** — group outputs by edge id into a nested map (`{"branch-a":{…},"branch-b":{…}}`).
+
+`DefaultMergeConfig` returns `append`.
+
+### Consequences
+
+- Good: the common fan-in shapes are one config field; no per-workflow merge code.
+- Good: explicit and validated; predictable defaults.
+- Bad: not arbitrarily expressive — a need outside the five requires a new strategy or an
+  extra transform node.
+- Neutral: `append`'s slice-vs-array coercion rules are subtle; documented in code.
+
+## Pros and Cons of the Options
+
+### Fixed named strategies (chosen)
+
+- Good: declarative, validated, covers the common cases, good default.
+- Bad: bounded expressiveness.
+
+### Single always-merge-object behavior
+
+- Good: simplest.
+- Bad: can't express list collection or branch selection; forces workarounds.
+
+### User expression per join
+
+- Good: maximal flexibility.
+- Bad: more complex/error-prone; overkill for the common shapes; harder to validate.
+
+## More Information
+
+- Code: `internal/workflow/merge.go` (`MergeConfig`, `MergeStrategyType`, `BranchInput`,
+  `ApplyMergeStrategy`, `DefaultMergeConfig`); configured via `NodeSchema.Merge`
+  ([ADR-0013](0013-workflow-schema-model-and-input-mapping.md)).
+- Related: [ADR-0011](0011-threading-model-and-foreach.md) (produces the parallel branch outputs).

--- a/docs/adr/0013-workflow-schema-model-and-input-mapping.md
+++ b/docs/adr/0013-workflow-schema-model-and-input-mapping.md
@@ -1,0 +1,86 @@
+# 0013. Workflow schema model and edge-based input mapping
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+A workflow must be defined declaratively (so it can be stored, versioned, and triggered) and
+compiled into something executable. We need a definition format for the graph and a way to move
+data between nodes whose input/output shapes don't have to match exactly.
+
+## Decision Drivers
+
+- Declarative, JSON/YAML-serializable definition that validates before execution.
+- Decouple a node's output shape from the next node's input shape.
+- Support both static (literal) inputs and data flowing from prior nodes.
+- Compile cleanly to the runtime graph + thread model
+  ([ADR-0011](0011-threading-model-and-foreach.md)).
+
+## Considered Options
+
+- **Three-layer schema (Graph/Node/Edge) with per-edge input mappings** (`schema`/`flow` sources).
+- **Nodes wire directly to each other** with implicit pass-through of full outputs.
+- **A single flat document** without an explicit edge object.
+
+## Decision Outcome
+
+Chosen option: **a composed three-layer schema with input mapping carried on edges.**
+
+- `GraphSchema` — `ID`, `Name`, `Nodes`, `Edges`, optional `Metadata`/`Tags`, `Timeout`,
+  `Concurrency`, `TriggerConfig` (`internal/workflow/graph_schema.go`).
+- `NodeSchema` — `ID`, `Function` (`package/function`), optional `Retry`, `Timeout`, `Merge`
+  (`node_schema.go`).
+- `EdgeSchema` — `ID`, `From`, `To`, optional `Conditional`, `Input []InputMapping`, `OnError`
+  (`edge_schema.go`).
+
+Schemas are submitted via `PUT /v1/schemas/{schemaID}`, validated with `go-playground/validator`,
+and compiled by `internal/workflow/graph.go` into a runtime `Graph` (node/edge lookup maps, the
+first node as trigger, thread assignment).
+
+**Input mapping** lives on each edge. An `InputMapping{Source, Variable, Value, MapTo}` has two
+sources: `SourceSchema` (a static literal `Value`) and `SourceFlow` (pull `Variable` =
+`"nodeID.outputField"` from the workflow's accumulated `aggregatedOutput` store). At edge
+traversal, values are type-coerced (`typeschema.ParseValue`) and validated against the target
+node's parameter schema, then handed to the downstream node as its input. Outputs are recorded
+into `aggregatedOutput` keyed by node id after each step, which is what `SourceFlow` reads.
+
+### Consequences
+
+- Good: definitions are storable/validatable/versionable
+  ([ADR-0014](0014-schema-versioning-and-rollback.md)); nodes compose without rigid contracts.
+- Good: explicit edges are the natural home for conditions ([ADR-0015](0015-conditional-routing-with-expr-lang.md)),
+  error routing (`OnError`), and merge wiring.
+- Bad: input mapping is an extra concept authors must learn; mapping/coercion errors surface at
+  runtime, not at schema-validation time.
+- Neutral: `Metadata`/`Tags` are open maps reserved for tooling.
+
+## Pros and Cons of the Options
+
+### Three-layer schema + edge input mapping (chosen)
+
+- Good: clean separation; flexible data binding; edges carry routing/error/merge semantics.
+- Bad: more concepts; runtime mapping errors.
+
+### Direct node-to-node pass-through
+
+- Good: less to author for simple flows.
+- Bad: forces output/input shapes to match; no clean place for conditions/error routing.
+
+### Flat document without edges
+
+- Good: compact.
+- Bad: routing, conditions, and data binding become implicit and hard to validate/extend.
+
+## More Information
+
+- Code: `internal/workflow/graph_schema.go`, `node_schema.go`, `edge_schema.go`, `graph.go`;
+  mapping in `internal/workflow/workflow.go` (`inputMapping`, `aggregatedOutput`); handler
+  `internal/handlers/workflow_schema.go`.
+- Related: [ADR-0014](0014-schema-versioning-and-rollback.md),
+  [ADR-0015](0015-conditional-routing-with-expr-lang.md),
+  [ADR-0012](0012-join-merge-strategies.md), [ADR-0004](0004-multi-trigger-workflow-initiation.md)
+  (`TriggerConfig` on the schema).

--- a/docs/adr/0014-schema-versioning-and-rollback.md
+++ b/docs/adr/0014-schema-versioning-and-rollback.md
@@ -1,0 +1,83 @@
+# 0014. Immutable schema versioning with an active-version pointer
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+Workflow schemas ([ADR-0013](0013-workflow-schema-model-and-input-mapping.md)) change over time,
+but workflows are long-running — an in-flight instance must keep executing against the definition
+it started with, while new triggers should use the latest approved definition. We need a
+versioning model that supports safe iteration, rollback, and history without mutating a schema
+that running workflows depend on.
+
+## Decision Drivers
+
+- Never mutate a schema in place (in-flight workflows depend on it).
+- Atomically switch which version new executions use.
+- Keep full history; support rollback and inspection.
+
+## Considered Options
+
+- **Immutable versions + an active-version pointer**, with rollback as a new version.
+- **Overwrite the schema in place** on each update.
+- **Git-style content-addressed schemas** (hash-identified, no explicit version numbers).
+
+## Decision Outcome
+
+Chosen option: **immutable versions with an active pointer.** Every `Upsert` creates a new
+`SchemaVersion` (`internal/workflow/versioned_schema.go`: `SchemaID`, `Version`, cloned
+`Schema`, `CreatedAt`, `Comment`, `IsActive`) — it never overwrites. The repository keeps, per
+schema id, the full `versions` slice and an `activeVersions` pointer
+(`internal/repositories/graph_memory.go`; Postgres equivalent). The new version becomes active
+and the previous one is marked inactive; `FindByID` returns the graph for the active version.
+
+Service operations (`internal/services/graph_service.go`):
+- `Upsert` → append version N (active).
+- `ListVersions` / `GetVersionHistory` → history + `{activeVersion, latestVersion, totalVersions}`.
+- `FindByIDAndVersion` → read any past version.
+- `SetActiveVersion` → repoint the active version atomically.
+- `Rollback(toVersion)` → clone an old version's content into a **new** version (N+1) and
+  activate it — rollback is forward-only, preserving history.
+
+REST: `PUT /v1/schemas/{id}`, `GET /v1/schemas/{id}/versions`,
+`POST /v1/schemas/{id}/versions/{v}/activate`, `POST /v1/schemas/{id}/rollback`.
+
+### Consequences
+
+- Good: in-flight workflows are unaffected by new versions; deployments flip versions atomically;
+  full audit/rollback.
+- Good: rollback-as-new-version keeps history linear and avoids destructive reverts.
+- Bad: storage grows with every upsert (mitigated by payload externalization,
+  [ADR-0019](0019-object-store-payload-externalization.md)); no automatic pruning/retention yet.
+- Neutral: callers choosing a specific version must pass it explicitly; default is the active one.
+
+## Pros and Cons of the Options
+
+### Immutable versions + active pointer (chosen)
+
+- Good: safe iteration, atomic switch, rollback, history.
+- Bad: unbounded version growth without retention.
+
+### Overwrite in place
+
+- Good: trivial, minimal storage.
+- Bad: breaks in-flight workflows; no history or rollback.
+
+### Content-addressed (hash) schemas
+
+- Good: natural dedup and immutability.
+- Bad: no human-friendly ordering; "active" still needs a pointer; bigger change for little gain
+  over numbered versions.
+
+## More Information
+
+- Code: `internal/workflow/versioned_schema.go`; `internal/services/graph_service.go`
+  (Upsert/ListVersions/SetActiveVersion/Rollback/GetVersionHistory);
+  `internal/repositories/graph_memory.go` (+ `postgres/graph.go`).
+- Related: [ADR-0013](0013-workflow-schema-model-and-input-mapping.md),
+  [ADR-0003](0003-in-memory-repositories-by-default.md),
+  [ADR-0018](0018-high-availability-and-clustering.md) (versions replicate across nodes).

--- a/docs/adr/0015-conditional-routing-with-expr-lang.md
+++ b/docs/adr/0015-conditional-routing-with-expr-lang.md
@@ -1,0 +1,79 @@
+# 0015. Conditional edge routing with expr-lang
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+Workflows need to branch: route to different downstream nodes based on a prior node's output
+(if/switch logic), and trigger workflows only for events matching some predicate. We need an
+expression mechanism that is expressive enough for real conditions yet safe to evaluate on
+user-supplied schemas (no arbitrary code execution).
+
+## Decision Drivers
+
+- Express non-trivial conditions (comparisons, boolean logic) over node output / event data.
+- Safe evaluation — no arbitrary code, sandboxed.
+- Lightweight (pure Go, no embedded VM/JS runtime).
+- A clear "otherwise" path so routing is total.
+
+## Considered Options
+
+- **expr-lang/expr expressions on edges, plus exact-match and default condition types.**
+- **Embed a scripting engine** (JS/Lua) for conditions.
+- **Exact value matching only** (no general expressions).
+
+## Decision Outcome
+
+Chosen option: **`expr-lang/expr` for expressions, alongside exact and default conditions.** An
+`EdgeCondition` (`internal/workflow/edge_schema.go`) has a `Type`:
+
+- `expression` — an `expr-lang` expression evaluated against an environment of all node outputs
+  (keyed by node id) plus `output` for the current node (e.g. `output.status == "success" && total > 100`).
+- `exact` — compare `Value` against the node's configured conditional output field.
+- `default` — always matches; the fallback when no other edge matches.
+
+`EvaluateCondition` (`internal/workflow/expression.go`) evaluates per type;
+`filterOutputEdgesByConditionals` (`internal/workflow/workflow.go`) picks the matching output
+edge(s): unconditional edges always pass, expression/exact edges are evaluated, and if none match
+the `default` edge is used. The same expr-lang engine powers **event-trigger filters**
+(`EventConfig.Filter`, `internal/actors/event_trigger.go`) — events are evaluated against their
+data and only matching ones trigger the workflow ([ADR-0004](0004-multi-trigger-workflow-initiation.md)).
+
+### Consequences
+
+- Good: expressive, safe (sandboxed, no arbitrary code), pure-Go, fast to compile/evaluate.
+- Good: one expression language for both edge routing and event filtering — one thing to learn.
+- Good: `default` guarantees total routing (no "stuck" node when nothing matches).
+- Bad: expression errors surface at runtime (a bad expression logs and skips the edge); authors
+  must know expr-lang syntax.
+- Neutral: edge-condition env and event-filter env are scoped differently (node outputs vs raw
+  event data) — intentional.
+
+## Pros and Cons of the Options
+
+### expr-lang + exact + default (chosen)
+
+- Good: expressive yet safe; pure Go; covers simple and complex branching; total routing.
+- Bad: runtime evaluation errors; another mini-language for authors.
+
+### Embedded scripting engine (JS/Lua)
+
+- Good: maximal expressiveness/familiarity.
+- Bad: heavy dependency; sandboxing/security burden; slower; overkill for routing predicates.
+
+### Exact match only
+
+- Good: trivial and safe.
+- Bad: can't express comparisons/boolean logic — forces extra nodes for real conditions.
+
+## More Information
+
+- Code: `internal/workflow/edge_schema.go` (`EdgeCondition`, `EdgeConditionType`),
+  `expression.go` (`EvaluateCondition`), `workflow.go` (`filterOutputEdgesByConditionals`),
+  `internal/actors/event_trigger.go` (event filters); dependency `github.com/expr-lang/expr`.
+- Related: [ADR-0013](0013-workflow-schema-model-and-input-mapping.md),
+  [ADR-0004](0004-multi-trigger-workflow-initiation.md).

--- a/docs/adr/0016-concurrency-and-rate-limiting.md
+++ b/docs/adr/0016-concurrency-and-rate-limiting.md
@@ -1,0 +1,78 @@
+# 0016. Multi-scope concurrency control and rate limiting
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+Workflow functions call real systems (HTTP APIs, the LLM providers in
+[ADR-0006](0006-llm-provider-abstraction-and-multi-provider-strategy.md), databases) that have
+their own limits. The engine must cap how many executions run at once and how fast they fire —
+globally per function, per workflow, and scoped to a key (e.g. per tenant/user) — without
+deadlocking the actor pipeline.
+
+## Decision Drivers
+
+- Limit concurrency at multiple scopes: per-function, per-workflow, and per-key.
+- Rate-limit calls over a time window, with a choice to queue or reject.
+- Don't deadlock the `WorkflowFunc` worker pool or the workflow supervisor.
+
+## Considered Options
+
+- **In-process semaphores (per scope) + token-bucket rate limiters**, config-declared per function/workflow.
+- **A single global worker-pool size** as the only throttle.
+- **An external rate-limiting service** (e.g. Redis-based).
+
+## Decision Outcome
+
+Chosen option: **in-process semaphores plus token buckets, declared in config.**
+`internal/concurrency/Manager` holds three semaphore maps — `functions`, `workflows`, `keyed`
+(`"scope:keyValue"`). Limits are declared as `ConcurrencyConfig{Limit (1–1000), Key}`
+(`pkg/workflow/concurrency.go`); a non-empty `Key` scopes the semaphore per key value.
+Semaphores are FIFO (`internal/concurrency/semaphore.go`): `Acquire` blocks for a slot (used for
+function concurrency in `internal/actors/workflow_func.go`), `TryAcquire` is non-blocking (used
+to admit workflows without blocking the supervisor — requeue if full).
+
+Rate limiting (`pkg/workflow/ratelimit.go`: `RateLimitConfig{Limit, Period, Key, Strategy}`)
+uses per-key token buckets (`internal/concurrency/token_bucket.go`, refill = limit/period). The
+**queue** strategy blocks until a token is available; the **reject** strategy returns an error
+immediately (surfaced as a `FunctionError` result). `WorkflowFunc` acquires the concurrency slot
+(blocking, `defer release()`) and applies the rate limiter before executing the function.
+
+### Consequences
+
+- Good: throttling at the right granularity (function / workflow / key); queue-vs-reject is a
+  per-function choice; no external dependency for single-node throughput control.
+- Good: blocking vs `TryAcquire` is chosen deliberately — block a pool worker, but never block
+  the supervisor (requeue instead) to avoid deadlock.
+- Bad: limits are **per process**, not cluster-wide — under HA each node enforces its own caps,
+  so global limits are approximate across nodes.
+- Neutral: keyed limits parse a key expression at runtime; bad keys degrade to unscoped.
+
+## Pros and Cons of the Options
+
+### In-process semaphores + token buckets (chosen)
+
+- Good: precise multi-scope control, queue/reject, zero external deps, fits the actor pool.
+- Bad: per-process only (not globally coordinated in HA).
+
+### Single global worker-pool size
+
+- Good: trivial.
+- Bad: one knob can't express per-function/per-key limits or rate windows.
+
+### External rate-limiting service (Redis)
+
+- Good: cluster-wide coordination.
+- Bad: heavy dependency, network hop per call, new failure mode; unnecessary for current needs.
+
+## More Information
+
+- Code: `internal/concurrency/` (`manager.go`, `semaphore.go`, `rate_limiter.go`,
+  `token_bucket.go`); config `pkg/workflow/concurrency.go`, `pkg/workflow/ratelimit.go`;
+  enforcement in `internal/actors/workflow_func.go`; DI `internal/app/di/concurrency.go`.
+- Related: [ADR-0002](0002-ergo-actor-model-for-workflow-execution.md),
+  [ADR-0018](0018-high-availability-and-clustering.md) (why limits are per-node under HA).

--- a/docs/adr/0017-idempotency-check-and-set.md
+++ b/docs/adr/0017-idempotency-check-and-set.md
@@ -1,0 +1,79 @@
+# 0017. Idempotent triggering via CheckAndSet with TTL
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+Triggers ([ADR-0004](0004-multi-trigger-workflow-initiation.md)) can fire more than once for the
+same logical event: a client retries an HTTP call, a cron tick fires on every HA node at once, or
+the same event is observed by multiple nodes. Without deduplication this spawns duplicate
+workflows. We need idempotent triggering that also works across HA nodes.
+
+## Decision Drivers
+
+- Deduplicate retried/duplicated triggers → at most one workflow per logical event.
+- Work across multiple HA nodes (the dedup decision must be atomic and shared).
+- Bounded storage (keys expire).
+- Pluggable with the persistence model ([ADR-0003](0003-in-memory-repositories-by-default.md)).
+
+## Considered Options
+
+- **An idempotency store with an atomic `CheckAndSet` + TTL**, memory and Postgres backends.
+- **Best-effort check-then-set** (separate read and write).
+- **Database unique constraints** on a derived key, catching conflict errors.
+
+## Decision Outcome
+
+Chosen option: **an idempotency store keyed by an idempotency key, with an atomic `CheckAndSet`
+and a TTL.** The `Store` interface (`internal/idempotency/store.go`) is
+`Check`, `Set`, `Delete`, and `CheckAndSet(key, workflowID, ttl) (existingID, existed)`. The
+memory backend guards `CheckAndSet` with a single write lock and purges expired entries
+periodically; the Postgres backend (`internal/repositories/postgres/idempotency.go`) does it
+atomically with `INSERT … ON CONFLICT DO NOTHING` + a CTE select, so concurrent HA nodes racing
+on the same key produce exactly one winner. TTL is config-driven (`IDEMPOTENCY_TTL`, default 24h).
+
+Usage by trigger type:
+- **HTTP** — client-supplied `idempotencyKey`: `Check` on arrival returns the existing workflow
+  id (response flagged `deduplicated`); `Set` after a successful trigger.
+- **Cron** — deterministic key `cron:{schemaID}:{minuteBucket}` with `CheckAndSet` (TTL ~1h): all
+  HA nodes fire together, only the first to set wins.
+- **Event/webhook** — deterministic key derived from schema + event type + source + data hash via
+  `CheckAndSet` (TTL ~10m).
+
+### Consequences
+
+- Good: at-most-once triggering per logical event, correct across HA nodes via atomic CheckAndSet.
+- Good: bounded storage via TTL; backend follows the same memory/Postgres split as other repos.
+- Bad: per-trigger TTLs (24h/1h/10m) are tuned constants, not yet centrally documented/configurable.
+- Neutral: dedup is at the *trigger* boundary; idempotency of side effects inside a workflow is a
+  separate concern (handled by journal replay, [ADR-0010](0010-durable-execution-journal-and-replay.md)).
+
+## Pros and Cons of the Options
+
+### Idempotency store with atomic CheckAndSet + TTL (chosen)
+
+- Good: race-free across nodes; bounded; uniform across trigger types.
+- Bad: scattered TTL constants.
+
+### Best-effort check-then-set
+
+- Good: simplest.
+- Bad: racy under HA — two nodes can both pass the check and both spawn a workflow.
+
+### DB unique constraint + conflict handling
+
+- Good: leverages the database for atomicity.
+- Bad: Postgres-only (no memory path); error-driven control flow; awkward TTL/expiry handling.
+
+## More Information
+
+- Code: `internal/idempotency/store.go`, `memory_store.go`;
+  `internal/repositories/postgres/idempotency.go`; DI `internal/app/di/idempotency.go`;
+  usage in `internal/handlers/trigger_workflow.go`, `internal/actors/cron_scheduler.go`,
+  `event_trigger.go`. Config: `IdempotencyConfig` (`internal/app/config/config.go`).
+- Related: [ADR-0004](0004-multi-trigger-workflow-initiation.md),
+  [ADR-0018](0018-high-availability-and-clustering.md).

--- a/docs/adr/0018-high-availability-and-clustering.md
+++ b/docs/adr/0018-high-availability-and-clustering.md
@@ -1,0 +1,89 @@
+# 0018. High availability: claims, clustering, and schema replication
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+For production, FUSE runs as multiple nodes so it survives a node failure and scales out. That
+requires: distributing workflow ownership across nodes (and recovering a dead node's work),
+nodes discovering each other for actor messaging, and keeping workflow schemas consistent
+cluster-wide. We want this without standing up a heavyweight consensus system.
+
+## Decision Drivers
+
+- No workflow lost or run twice when a node dies (failover).
+- Dynamic node discovery (incl. Kubernetes autoscaling).
+- Cluster-wide schema consistency.
+- Reuse existing infra (Postgres, ergo) over adding Raft/ZooKeeper.
+
+## Considered Options
+
+- **DB lease-based claims + ergo clustering (static or etcd discovery) + Postgres LISTEN/NOTIFY +
+  ergo-Event schema replication.**
+- **A consensus system** (Raft/etcd-as-coordinator) owning scheduling.
+- **External queue** distributing work to stateless workers.
+
+## Decision Outcome
+
+Chosen option: **lease-based DB claims + ergo clustering + LISTEN/NOTIFY, composed from existing
+infrastructure.** Three mechanisms:
+
+1. **Work claiming (failover).** `ClaimRepository` (Postgres) lets each node atomically claim
+   unclaimed or lease-expired workflows with `UPDATE … FOR UPDATE SKIP LOCKED`. A
+   `WorkflowClaimActor` periodically sweeps (`HA_CLAIM_SWEEP_INTERVAL`, default 5s), heartbeats
+   (`node_heartbeats`), and reassigns workflows from nodes whose heartbeat is older than
+   `HA_LEASE_TIMEOUT` (default 30s). The memory backend is a no-op (HA off).
+
+2. **Lower-latency claims.** A `PgListenerActor` subscribes to Postgres **LISTEN/NOTIFY**
+   (`workflow_state_change`) on a dedicated connection; a newly available workflow nudges the
+   claim actor (`ClaimSweepNowMsg`) to claim immediately instead of waiting for the next sweep.
+
+3. **Discovery + replication.** ergo clustering is enabled by `CLUSTER_ENABLED` with a shared
+   `cookie` and acceptor port; discovery is **static** (`CLUSTER_PEER_NODES`) or **etcd**
+   (`ergo.services/registrar/etcd`, lease-based, for dynamic peers/autoscaling). Schema upserts
+   propagate via an ergo **Event** (`fuse_graph_schema_upsert`): the `SchemaReplicationActor`
+   monitors peers (static list or etcd-discovered) and applies replicated upserts idempotently,
+   so [ADR-0014](0014-schema-versioning-and-rollback.md) versions stay consistent across nodes.
+
+### Consequences
+
+- Good: node failure self-heals (lease expiry → reclaim); no extra coordinator to operate;
+  builds on Postgres + ergo already in the stack; etcd path supports HPA.
+- Good: LISTEN/NOTIFY gives near-real-time claiming without tight polling.
+- Bad: HA correctness requires Postgres ([ADR-0003](0003-in-memory-repositories-by-default.md)) —
+  the memory backend is single-node only.
+- Bad: schema replication is best-effort ergo-Event fan-out (no quorum) — eventual, not strongly
+  consistent; concurrency limits are per-node ([ADR-0016](0016-concurrency-and-rate-limiting.md)).
+- Neutral: failover granularity/latency is bounded by the sweep interval and lease timeout.
+
+## Pros and Cons of the Options
+
+### DB claims + ergo + LISTEN/NOTIFY (chosen)
+
+- Good: reuses existing infra; self-healing; dynamic discovery; low operational burden.
+- Bad: Postgres-dependent; eventual schema consistency; per-node limits.
+
+### Consensus system owning scheduling
+
+- Good: strong consistency, principled leader/partition handling.
+- Bad: heavy to run and reason about; large addition for the gains needed here.
+
+### External queue + stateless workers
+
+- Good: mature horizontal scaling.
+- Bad: doesn't fit stateful, resumable, per-instance workflow execution; another system to run.
+
+## More Information
+
+- Code: `internal/repositories/claim.go` (+ `postgres/claim.go`),
+  `internal/actors/workflow_claim_actor.go`, `internal/actors/pg_listener_actor.go`,
+  `internal/repositories/postgres/listener.go`, `internal/actors/schema_replication_actor.go`,
+  `internal/app/fuse.go` (ergo cluster + etcd registrar). Config: `HAConfig`, `ClusterConfig`
+  (`internal/app/config/config.go`).
+- Related: [ADR-0002](0002-ergo-actor-model-for-workflow-execution.md),
+  [ADR-0003](0003-in-memory-repositories-by-default.md),
+  [ADR-0017](0017-idempotency-check-and-set.md), [ADR-0014](0014-schema-versioning-and-rollback.md).

--- a/docs/adr/0019-object-store-payload-externalization.md
+++ b/docs/adr/0019-object-store-payload-externalization.md
@@ -1,0 +1,77 @@
+# 0019. Externalize large payloads to a pluggable object store
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+Durable execution ([ADR-0010](0010-durable-execution-journal-and-replay.md)) and versioning
+([ADR-0014](0014-schema-versioning-and-rollback.md)) produce large blobs: schema definitions,
+journals, execution traces, and node inputs/outputs. Storing these inline in the primary
+(relational) store bloats it and couples hot metadata to cold payloads. We need a place for
+large payloads that scales independently and works from laptop to cloud.
+
+## Decision Drivers
+
+- Keep the primary store lean (metadata) and put large blobs elsewhere.
+- One abstraction, several backends (zero-dep local dev → cloud in prod).
+- Independent scaling/lifecycle for payloads.
+
+## Considered Options
+
+- **A pluggable `ObjectStore` interface (memory / filesystem / S3); DB rows hold metadata + a key.**
+- **Store everything in Postgres** (large `bytea`/JSONB columns).
+- **Filesystem only.**
+
+## Decision Outcome
+
+Chosen option: **a pluggable object store.** `pkg/objectstore` defines a minimal interface —
+`Put(ctx,key,data)`, `Get`, `Delete` (idempotent), `Exists` — with three implementations chosen
+by `OBJECT_STORE_DRIVER` (`internal/app/di/objectstore.go`): `memory` (default, dev/test),
+`filesystem` (disk/NFS/PVC), and `s3` (S3-compatible via `minio-go`, works with AWS S3, MinIO,
+rustfs, LocalStack; auto-creates the bucket). Config is `ObjectStoreConfig` (bucket, endpoint,
+region, keys, SSL, key prefix).
+
+Postgres repositories store **metadata in tables and the payload in the object store**, keyed by a
+hierarchical path — e.g. traces at `workflows/{workflowID}/trace/{execID}/{input|output}.json`,
+schemas at `schemas/{schemaID}/v{n}/definition.json`. The relational row references the object
+key; the blob lives in the store.
+
+### Consequences
+
+- Good: primary store stays small; payloads scale independently and cheaply (S3); same code path
+  from local dev (memory/fs) to prod (S3).
+- Good: backend is swappable by config, no code change.
+- Bad: a logical record spans two stores (row + object) → possible orphaned objects; no built-in
+  GC/retention yet.
+- Neutral: the memory/filesystem drivers are not durable/shared across nodes — HA uses S3 (or a
+  shared volume) so all nodes see the same payloads.
+
+## Pros and Cons of the Options
+
+### Pluggable ObjectStore (chosen)
+
+- Good: lean primary store; dev→prod parity; independent payload scaling.
+- Bad: two-store consistency; orphan cleanup not yet automated.
+
+### Everything in Postgres
+
+- Good: single store, transactional with metadata.
+- Bad: DB bloat and cost for large/cold blobs; backups/scaling get heavy.
+
+### Filesystem only
+
+- Good: simple, durable on one host.
+- Bad: no shared access across HA nodes without network FS; no cloud-native scaling.
+
+## More Information
+
+- Code: `pkg/objectstore/store.go` (interface), `s3.go` (minio-go), memory/filesystem impls;
+  `internal/app/di/objectstore.go`; payload keys in `internal/repositories/postgres/` (trace.go,
+  graph.go, etc.). Config: `ObjectStoreConfig` (`internal/app/config/config.go`).
+- Related: [ADR-0003](0003-in-memory-repositories-by-default.md),
+  [ADR-0010](0010-durable-execution-journal-and-replay.md),
+  [ADR-0018](0018-high-availability-and-clustering.md).

--- a/docs/adr/0020-observability-metrics-tracing-execution-traces.md
+++ b/docs/adr/0020-observability-metrics-tracing-execution-traces.md
@@ -1,0 +1,85 @@
+# 0020. Observability: Prometheus metrics, OpenTelemetry tracing, execution traces
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+Operators need to monitor a fleet of FUSE nodes (throughput, failures, latency) and debug
+individual workflow runs (what ran, with what input/output, how long, why it failed). These are
+two different audiences — aggregate metrics and per-execution detail — and tracing may or may not
+have a collector available. We need an approach that serves both and degrades gracefully.
+
+## Decision Drivers
+
+- Standard, scrapeable metrics for dashboards/alerts.
+- Distributed tracing that's optional (works with no collector configured).
+- Per-execution, queryable debugging data without requiring an external tracing stack.
+- Isolation from global registries / no nil-checks scattered in code.
+
+## Considered Options
+
+- **Three complementary layers: Prometheus metrics + optional OTel tracing + a persisted
+  execution trace.**
+- **Metrics only.**
+- **OpenTelemetry for everything** (metrics + traces) via a required collector.
+
+## Decision Outcome
+
+Chosen option: **three layers, each for its job.**
+
+1. **Metrics (Prometheus).** A dedicated `FuseMetrics` registry (`internal/metrics/registry.go`)
+   exposes `fuse_*` series — `workflows_active` (gauge), `workflows_completed/failed/cancelled_total`
+   (counters), `node_exec_duration_seconds` (histogram, labels `function_id`, `status`) — plus an
+   ergo runtime collector (`ergo_*`) and Go/process collectors, served at `GET /metrics`
+   (OpenMetrics) by the mux server. A dedicated registry avoids polluting global Prometheus state.
+
+2. **Tracing (OpenTelemetry).** `internal/tracing/provider.go` exports spans over OTLP/gRPC when
+   `OTEL_ENABLED=true`; when disabled it returns a **no-op provider** so call sites never nil-check.
+   W3C TraceContext + Baggage propagators let span context ride on actor messages
+   (`InjectCarrier`/`ExtractCarrier`): a root span per workflow, child `node.execute` spans with
+   workflow/exec/function/package attributes.
+
+3. **Execution trace (domain).** `ExecutionTrace`/`ExecutionStepTrace` (`internal/workflow/trace.go`)
+   is a persisted, per-run record (status, timings, per-step input/output/attempt/error), stored
+   via Postgres + object store ([ADR-0019](0019-object-store-payload-externalization.md)) and
+   queryable at `GET /v1/workflows/{id}/trace` — debugging detail with **no external collector**.
+
+### Consequences
+
+- Good: aggregate monitoring (Prometheus), distributed tracing when wanted (OTel), and always-on
+  per-run debugging (execution trace) — each audience served.
+- Good: tracing is optional (no-op fallback); metrics registry is isolated.
+- Bad: the execution trace overlaps conceptually with OTel spans (two "trace" notions) — kept
+  because it's queryable without a collector and persisted with the workflow.
+- Neutral: OTel sampling/retention for execution traces aren't yet centrally tuned.
+
+## Pros and Cons of the Options
+
+### Three layers (chosen)
+
+- Good: right tool per need; graceful degradation; no hard dependency on a tracing stack.
+- Bad: two "trace" concepts to understand; more surface area.
+
+### Metrics only
+
+- Good: simplest.
+- Bad: no request-level debugging or distributed correlation.
+
+### OTel for everything (required collector)
+
+- Good: one standard, unified.
+- Bad: forces a collector to exist; loses the always-available, persisted-with-the-workflow
+  execution trace.
+
+## More Information
+
+- Code: `internal/metrics/registry.go`, `ergo_collector.go`; `internal/actors/mux_server.go`
+  (`/metrics`); `internal/tracing/provider.go`; span use in
+  `internal/actors/workflow_handler.go` + `workflow_func.go`; `internal/workflow/trace.go`
+  (+ `postgres/trace.go`). Config: `OtelConfig` (`internal/app/config/config.go`).
+- Related: [ADR-0019](0019-object-store-payload-externalization.md),
+  [ADR-0010](0010-durable-execution-journal-and-replay.md) (journal vs trace: replay vs observability).

--- a/docs/adr/0021-deployment-and-delivery-architecture.md
+++ b/docs/adr/0021-deployment-and-delivery-architecture.md
@@ -1,0 +1,94 @@
+# 0021. Deployment and delivery architecture (CI/CD, Docker, Helm)
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records the existing delivery and deployment architecture.
+
+## Context and Problem Statement
+
+FUSE must ship reliably from commit to a running, highly-available deployment. We need to define
+how code is gated and released, how the artifact is built, how it is packaged for Kubernetes, and
+how the HA topology ([ADR-0018](0018-high-availability-and-clustering.md)) is expressed in
+infrastructure — in a way that's reproducible for contributors and operators.
+
+## Decision Drivers
+
+- Enforce the quality gate (lint → build → test) and integration (E2E) before release.
+- Reproducible, small, secure runtime image.
+- Automated, semantic versioning of both the app image and the deployable chart.
+- A Kubernetes deployment that supports both standalone and clustered/HA modes, plus a
+  one-command local stack mirroring it.
+
+## Considered Options
+
+- **GitHub Actions (CI → E2E → CD) + semantic-release + multi-arch distroless image +
+  Helm/OCI chart, with profile-based docker-compose for local/E2E.**
+- **Manual/tag-driven releases.**
+- **Plain Kubernetes manifests (kustomize) instead of Helm.**
+
+## Decision Outcome
+
+Chosen option: **a fully automated GitHub Actions pipeline producing a distroless image and an
+OCI Helm chart, with a profile-based docker-compose mirror for local dev and E2E.**
+
+- **CI** (`.github/workflows/ci.yml`): on push/PR — Go 1.26, `make swagger/lint/build/test`
+  (golangci-lint v2, gotestsum) + benchmarks, `helm lint`/`template` validation, then functional
+  tests against a real Postgres 17 service; PRs additionally build and push a `pr-<n>` image
+  (DockerHub, gated by `environment: prod`).
+- **E2E** (`e2e.yml`): after CI — builds `fuse-app:test`, brings up the `e2e` docker-compose
+  profile (3 nodes + Postgres + S3/rustfs + etcd), health-checks, runs `-tags=e2e` tests; a
+  `e2e-slow` tier runs on `main`.
+- **CD** (`cd.yml`): after E2E on `main` — `go-semantic-release` derives the version from
+  conventional commits; on a release it builds a **multi-arch (amd64/arm64)** image, tags
+  `:latest`/`:<version>`, Trivy-scans (SARIF → GitHub Security), and **publishes the Helm chart
+  to a separate OCI repo** (`fuse-chart`) after bumping its version. App image and chart are
+  distinct repositories.
+- **Image** (`Dockerfile`): multi-stage — `golang:1.26` builds a static `CGO_ENABLED=0` binary
+  (with swagger gen); runtime is `gcr.io/distroless/static-debian12`, non-root, `EXPOSE 9090`.
+- **Helm chart** (`deploy/helm/fuse/`): `mode: standalone` → Deployment, `mode: cluster` →
+  StatefulSet (headless service, `POD_NAME`/`POD_IP`/`CLUSTER_NODE_NAME` injected, acceptor port
+  for ergo). Values cover image, cluster (static or etcd discovery, cookie, acceptor), database,
+  object store, HA intervals, service, `/health` probes, and HPA (cluster + etcd discovery).
+- **Local/E2E** (`docker-compose.yml`): profiles `infra` (PG + rustfs S3 + etcd), `ha` (3 nodes
+  built from source + nginx round-robin LB), `e2e` (3 nodes from the prebuilt image + migrate
+  init). This mirrors the K8s HA topology for `make infra-up`/`ha-up`.
+
+### Consequences
+
+- Good: every release passes the same gates (lint/build/test → functional → E2E); versions are
+  automated and traceable; the runtime image is small, static, non-root, and scanned.
+- Good: one chart serves standalone and HA; the compose stack reproduces the cluster locally.
+- Good: separating app image and chart repos lets them version independently.
+- Bad: the pipeline is GitHub-Actions- and DockerHub-specific (CI provider / registry lock-in);
+  schema replication under HA remains best-effort ([ADR-0018](0018-high-availability-and-clustering.md)).
+- Neutral: in-memory state means multi-replica standalone needs sticky sessions or `mode: cluster`;
+  HA correctness needs Postgres + shared object store.
+
+## Pros and Cons of the Options
+
+### Actions + semantic-release + distroless + Helm/OCI (chosen)
+
+- Good: automated, gated, reproducible, secure image, K8s-native, local parity.
+- Bad: CI/registry-specific; more moving parts to maintain.
+
+### Manual/tag-driven releases
+
+- Good: simple, full control.
+- Bad: error-prone, inconsistent gating, no automated semver.
+
+### Raw manifests / kustomize
+
+- Good: no templating engine.
+- Bad: harder to parameterize standalone-vs-cluster, HA, and external deps; no chart distribution.
+
+## More Information
+
+- CI/CD: `.github/workflows/{ci,cd,e2e}.yml`; release via `go-semantic-release`;
+  `scripts/bump-version.sh`. Image: `Dockerfile`. Chart: `deploy/helm/fuse/` (+ `deploy/k3s`,
+  `deploy/kind`, `deploy/nginx`). Local: `docker-compose.yml` profiles; `docs/DEPLOYMENT.md`,
+  `docs/SETUP.md`.
+- Related: [ADR-0018](0018-high-availability-and-clustering.md),
+  [ADR-0003](0003-in-memory-repositories-by-default.md),
+  [ADR-0019](0019-object-store-payload-externalization.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,15 @@ copying [`template.md`](template.md).
 | 0007 | [Agent reasoning loop & tools-from-functions](0007-agent-reasoning-loop-and-tools-from-functions.md) | Proposed | 2026-06-01 |
 | 0008 | [Settings, environments & secrets management](0008-settings-environments-and-secrets-management.md) | Proposed | 2026-06-01 |
 | 0009 | [Portable AI agent guidance in `.agents/`](0009-portable-ai-agent-guidance.md)         | Accepted | 2026-06-01 |
+| 0010 | [Durable execution via an append-only journal](0010-durable-execution-journal-and-replay.md) | Accepted | 2026-06-01 |
+| 0011 | [Thread model for fork/join and ForEach](0011-threading-model-and-foreach.md)            | Accepted | 2026-06-01 |
+| 0012 | [Configurable merge strategies at join nodes](0012-join-merge-strategies.md)             | Accepted | 2026-06-01 |
+| 0013 | [Workflow schema model and edge-based input mapping](0013-workflow-schema-model-and-input-mapping.md) | Accepted | 2026-06-01 |
+| 0014 | [Immutable schema versioning with active-version pointer](0014-schema-versioning-and-rollback.md) | Accepted | 2026-06-01 |
+| 0015 | [Conditional edge routing with expr-lang](0015-conditional-routing-with-expr-lang.md)    | Accepted | 2026-06-01 |
+| 0016 | [Multi-scope concurrency control and rate limiting](0016-concurrency-and-rate-limiting.md) | Accepted | 2026-06-01 |
+| 0017 | [Idempotent triggering via CheckAndSet with TTL](0017-idempotency-check-and-set.md)      | Accepted | 2026-06-01 |
+| 0018 | [High availability: claims, clustering, schema replication](0018-high-availability-and-clustering.md) | Accepted | 2026-06-01 |
+| 0019 | [Externalize large payloads to a pluggable object store](0019-object-store-payload-externalization.md) | Accepted | 2026-06-01 |
+| 0020 | [Observability: metrics, tracing, execution traces](0020-observability-metrics-tracing-execution-traces.md) | Accepted | 2026-06-01 |
+| 0021 | [Deployment and delivery architecture (CI/CD, Docker, Helm)](0021-deployment-and-delivery-architecture.md) | Accepted | 2026-06-01 |


### PR DESCRIPTION
## Context

Completes the ADR program (W1 + W2): records the engine's remaining foundational decisions and the delivery/deployment architecture as MADR ADRs. Each was authored **grounded in the actual code** (verified file paths, structs, and mechanisms), not from memory — backfill should be honest extraction.

This finishes the four-workstream effort: W3 portable `.agents/` (#71) → W4 ADR skills (#72) → **W1 backfill + W2 deployment (this PR)**.

## ADRs added (all Accepted)

**Execution core**
- `0010` Durable execution via an append-only journal (+ awakeables, sub-workflows)
- `0011` Thread model for fork/join and ForEach iteration
- `0012` Configurable merge strategies at join nodes

**Schema & routing**
- `0013` Workflow schema model and edge-based input mapping
- `0014` Immutable schema versioning with an active-version pointer
- `0015` Conditional edge routing with expr-lang

**Concurrency, idempotency, HA**
- `0016` Multi-scope concurrency control and rate limiting
- `0017` Idempotent triggering via CheckAndSet with TTL
- `0018` High availability: claims, clustering, schema replication

**Infrastructure & delivery**
- `0019` Externalize large payloads to a pluggable object store
- `0020` Observability: Prometheus metrics, OTel tracing, execution traces
- `0021` Deployment and delivery architecture (CI/CD, Docker, Helm)

## Verification

- All 12 files present; every index-table link resolves; all 21 distinct cross-ADR links resolve; no secrets.
- Docs only — no Go changes.

Reviewable per-ADR. Each ends with a *More Information* section linking the source files/types and related ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)