### PR TITLE
docs(adr): execution-semantics decisions (0022-0024)

### DIFF
--- a/docs/adr/0022-retry-and-error-handling-model.md
+++ b/docs/adr/0022-retry-and-error-handling-model.md
@@ -1,0 +1,96 @@
+# 0022. Retry and error-handling model
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+Workflow nodes call fallible systems (HTTP APIs, LLM providers, databases). When a node fails,
+the engine must decide what happens next: retry it, route the workflow down an alternative path,
+or fail the workflow. The durable journal ([ADR-0010](0010-durable-execution-journal-and-replay.md))
+records *that* a node failed and was retried, but the *policy* — how many times, with what delay,
+and what happens when retries run out — is a separate execution-semantics decision that needs to
+be explicit and configurable per node.
+
+## Decision Drivers
+
+- Transient failures (timeouts, 5xx, rate limits) should be retried automatically with backoff.
+- Authors need per-node control (a flaky HTTP call ≠ a deterministic transform).
+- A graph-level way to handle "this step failed" without crashing the whole workflow.
+- Deterministic, journaled, and replay-safe ([ADR-0010](0010-durable-execution-journal-and-replay.md)).
+
+## Considered Options
+
+- **Per-node retry policy with backoff + first-class error edges, with an ordered fallback
+  retry → error-edge → fail-workflow.**
+- **Retry-only** (retry with backoff; on exhaustion, always fail the workflow).
+- **Fail-fast** (no retries; any node error fails the workflow).
+- **A single global retry setting** for all nodes.
+
+## Decision Outcome
+
+Chosen option: **per-node `RetryPolicy` + error edges, evaluated as an ordered fallback.**
+
+- `RetryPolicy` (`internal/workflow/retry.go`) on `NodeSchema.Retry`: `MaxAttempts` (0–100, 0 = no
+  retries) and a `BackoffConfig{Type, InitialInterval, MaxInterval, Multiplier}` where
+  `BackoffType` is `fixed | exponential | linear`. `DefaultRetryPolicy` = 3 attempts, exponential,
+  1s → 30s cap, ×2; `DelayFor(attempt)` computes the per-attempt delay.
+- A `RetryTracker` (`retry_tracker.go`) counts attempts per `execID`.
+- `Workflow.HandleNodeFailure` (`workflow.go`) is the decision point: if a retry policy applies and
+  `attempts <= MaxAttempts`, it returns a `RetryFunctionAction` with the computed delay and journals
+  `step:retrying`; once retries are exhausted it clears the tracker and looks for **error edges**
+  (`EdgeSchema.OnError`) — if present, execution continues down the first error edge (marking the
+  source thread finished when the edge crosses threads, [ADR-0011](0011-threading-model-and-foreach.md));
+  if none, it returns nil and the caller transitions the workflow to `StateError`. A failed node can
+  also be re-run on demand via the manual `RetryNode` path.
+
+Logical failures are carried in the function's `FunctionOutput` (status `error`), distinct from Go
+errors for unexpected execution faults, so the engine always gets a result to act on.
+
+### Consequences
+
+- Good: transient failures self-heal with tuned backoff; authors control behavior per node;
+  error edges express "on failure, do X" as ordinary graph routing; everything is journaled and
+  replay-safe.
+- Good: composes with timeouts ([ADR-0023](0023-timeout-enforcement-model.md)) — a timeout fires a
+  failure that flows through this same path.
+- Bad: retrying a non-idempotent node can duplicate side effects (the engine retries the function,
+  it can't know if the external effect already happened) — authors must design idempotent steps or
+  use idempotency keys ([ADR-0017](0017-idempotency-check-and-set.md)).
+- Neutral: only the first error edge is followed; multiple error branches aren't fanned out.
+
+## Pros and Cons of the Options
+
+### Per-node policy + error edges (chosen)
+
+- Good: granular, expressive (retry *and* alternative routing), journaled, sensible default.
+- Bad: duplicate-side-effect risk on retry; per-node config to author.
+
+### Retry-only
+
+- Good: simpler — one mechanism.
+- Bad: no graph-level recovery; a permanently failing step always kills the workflow.
+
+### Fail-fast
+
+- Good: trivial; no duplicate-effect risk.
+- Bad: no resilience to transient faults — unacceptable for real integrations.
+
+### Single global retry setting
+
+- Good: nothing to configure per node.
+- Bad: one policy can't fit both flaky I/O and deterministic compute; no error-routing.
+
+## More Information
+
+- Code: `internal/workflow/retry.go` (`RetryPolicy`, `BackoffConfig`, `DelayFor`),
+  `retry_tracker.go`, `workflow.go` (`HandleNodeFailure`, `findErrorEdges`, `RetryNode`),
+  `node_schema.go` (`Retry`), `edge_schema.go` (`OnError`);
+  retry/error actions handled in `internal/actors/workflow_handler.go`.
+- Related: [ADR-0010](0010-durable-execution-journal-and-replay.md),
+  [ADR-0023](0023-timeout-enforcement-model.md),
+  [ADR-0017](0017-idempotency-check-and-set.md),
+  [ADR-0013](0013-workflow-schema-model-and-input-mapping.md).

--- a/docs/adr/0023-timeout-enforcement-model.md
+++ b/docs/adr/0023-timeout-enforcement-model.md
@@ -1,0 +1,85 @@
+# 0023. Timeout enforcement via actor timers
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+A node's function can hang (a stuck HTTP call, a slow LLM, an external async step that never
+resolves), and a whole workflow can run longer than is acceptable. The engine needs to bound both
+without blocking its actor pipeline — execution is message-driven and often async
+([ADR-0002](0002-ergo-actor-model-for-workflow-execution.md),
+[ADR-0010](0010-durable-execution-journal-and-replay.md)), so a node may be "in flight" with no
+goroutine to cancel.
+
+## Decision Drivers
+
+- Bound individual node execution and total workflow duration.
+- Must work for async/long-running steps where no blocking call is in progress.
+- Don't tie up `WorkflowFunc` pool workers or the handler waiting on timers.
+- Cancellable cleanly when the step finishes in time.
+
+## Considered Options
+
+- **Asynchronous ergo `SendAfter` timer messages**, tracked and cancelled per execution.
+- **`context.WithTimeout` per execution goroutine** (block on ctx in the function call).
+- **No engine-level timeouts** — rely on each function's own client timeouts.
+
+## Decision Outcome
+
+Chosen option: **async timer messages via ergo `SendAfter`.** Two scopes
+(`internal/workflow/timeout.go`): per-node `TimeoutConfig.Execution` and per-workflow
+`GraphTimeoutConfig.Total` (zero = no timeout). An `ExecutionTimer`
+(`internal/actors/execution_timer.go`) starts a node timeout with
+`process.SendAfter(target, NewTimeoutMessage(execID), timeout)`, stores the returned
+`gen.CancelFunc` keyed by `execID`, and `Cancel(execID)` cancels it when the result arrives
+(`CancelAll` on teardown). The workflow-total timeout is a separate `SendAfter` set by the
+`WorkflowHandler` at start. When a timer fires, a `TimeoutMessage` reaches the handler, which
+fails that execution — and the failure then flows through the retry/error path
+([ADR-0022](0022-retry-and-error-handling-model.md)).
+
+Because timeouts are messages, they don't occupy a worker or block the handler, and they work
+even when the node is parked waiting on an external async result.
+
+### Consequences
+
+- Good: bounds both node and workflow duration; fits the non-blocking, async, actor-based pipeline;
+  covers async/awaitable steps that have no goroutine to cancel.
+- Good: a fired timeout reuses the existing failure semantics (retry → error-edge → fail) rather
+  than a separate code path.
+- Bad: requires explicit cancel bookkeeping (cancel on completion) — a missed cancel would fire a
+  spurious timeout (mitigated by `Cancel`/`CancelAll`).
+- Neutral: the timer fires the *engine's* notion of timeout; an in-flight external call may keep
+  running on the remote side (no forced cancellation of the remote work).
+
+## Pros and Cons of the Options
+
+### Async `SendAfter` timers (chosen)
+
+- Good: non-blocking, works for async steps, cancellable, reuses the failure path.
+- Bad: manual cancel tracking; doesn't abort remote work.
+
+### `context.WithTimeout` per goroutine
+
+- Good: idiomatic Go; cancels the in-progress call.
+- Bad: assumes a blocking call to cancel — doesn't fit parked/async executions or the message-driven
+  model; ties a goroutine to each pending node.
+
+### No engine-level timeouts
+
+- Good: nothing to build.
+- Bad: a hung node or runaway workflow has no backstop; relies on every function getting its own
+  client timeout right.
+
+## More Information
+
+- Code: `internal/workflow/timeout.go` (`TimeoutConfig`, `GraphTimeoutConfig`);
+  `internal/actors/execution_timer.go` (`Start`/`Cancel`/`CancelAll`);
+  `internal/actors/workflow_handler.go` (workflow-total timer, `TimeoutMessage` handling);
+  `internal/messaging` (`NewTimeoutMessage`).
+- Related: [ADR-0002](0002-ergo-actor-model-for-workflow-execution.md),
+  [ADR-0022](0022-retry-and-error-handling-model.md),
+  [ADR-0010](0010-durable-execution-journal-and-replay.md).

--- a/docs/adr/0024-package-registry-and-function-metadata.md
+++ b/docs/adr/0024-package-registry-and-function-metadata.md
@@ -1,0 +1,89 @@
+# 0024. Function packages: a registry with declarative metadata as contract
+
+- Status: Accepted
+- Date: 2026-06-01
+- Deciders: FUSE maintainers
+
+> Backfill ADR: records a foundational decision already implemented.
+
+## Context and Problem Statement
+
+A workflow node references "a function" to execute. The engine needs a model for what a function
+*is*: how it's discovered, how its inputs/outputs are described well enough to validate schemas,
+route conditional edges, and (later) generate LLM tool schemas, and how it's invoked. A bare Go
+function pointer carries none of that contract. This model underpins nodes, the schema layer
+([ADR-0013](0013-workflow-schema-model-and-input-mapping.md)), conditional routing
+([ADR-0015](0015-conditional-routing-with-expr-lang.md)), and agent tools
+([ADR-0007](0007-agent-reasoning-loop-and-tools-from-functions.md)).
+
+## Decision Drivers
+
+- Describe a function's typed inputs/outputs declaratively (validate before running).
+- Discover functions by id (`package/function`) and manage them at runtime via the API.
+- Carry per-function execution attributes (transport, concurrency, rate limit, conditional edges).
+- One contract reusable across nodes, the REST API, and agent tool generation.
+
+## Considered Options
+
+- **First-class `Package`/`PackagedFunction` units with declarative `FunctionMetadata`, held in a
+  registry.**
+- **Raw Go function pointers** referenced directly, with shapes known only at call time.
+- **An external RPC/plugin contract** (every function is an out-of-process service).
+
+## Decision Outcome
+
+Chosen option: **declarative, metadata-described functions in a registry.** A `Package`
+(`pkg/workflow/package.go`) groups `PackagedFunction`s, each pairing an executable `Function` with
+`FunctionMetadata` (`pkg/workflow/metadata.go`): `InputMetadata`/`OutputMetadata` made of
+`ParameterSchema{Name, Type, Required, Validations, Description, Default}`, plus conditional-edge
+metadata, transport, and concurrency/rate-limit config. A `Registry`
+(`internal/packages/registry.go`, `MemoryRegistry`: `Register`/`Get`/`Has`/`List`) holds
+`LoadedPackage`s; `LoadedPackage.ExecuteFunction` runs a function through its transport
+([ADR transport seam] — `internal/packages/transport`). Built-in packages register at startup
+(`internal_packages.go` `RegisterInternalPackages`); packages are introspectable/manageable over
+`GET /v1/packages` and `PUT/GET /v1/packages/{id}`.
+
+This metadata is the single typed contract reused everywhere: nodes validate and coerce inputs
+against it, conditional output fields/edges are declared in it, and agent tool schemas are derived
+from `Input.Parameters` ([ADR-0007](0007-agent-reasoning-loop-and-tools-from-functions.md)).
+
+### Consequences
+
+- Good: schemas can be validated before execution (do inputs match? is this edge valid?); one
+  contract powers nodes, the API, and agent tools; functions are discoverable and self-describing.
+- Good: per-function execution policy (concurrency/rate limit — [ADR-0016](0016-concurrency-and-rate-limiting.md))
+  travels with the metadata.
+- Bad: authoring a function means authoring its metadata too (more boilerplate than a bare func).
+- Neutral: today functions register **in-process** at startup; out-of-process/remote functions
+  await an HTTP/gRPC transport implementation (the transport interface exists with `Internal` built
+  and `HTTP`/`gRPC` stubbed — a separate future decision).
+
+## Pros and Cons of the Options
+
+### Registry + declarative metadata (chosen)
+
+- Good: validation, introspection, one reusable contract, per-function policy.
+- Bad: metadata boilerplate per function.
+
+### Raw Go function pointers
+
+- Good: minimal; no metadata to write.
+- Bad: no typed contract — can't validate schemas/edges or generate tool schemas; not manageable
+  over an API.
+
+### External RPC/plugin contract for all functions
+
+- Good: language-agnostic, strong isolation.
+- Bad: heavy for built-ins; network hop and operational cost for every call; overkill now (kept as
+  a future option behind the transport seam).
+
+## More Information
+
+- Code: `pkg/workflow/package.go` (`Package`, `PackagedFunction`, `NewPackage`/`NewFunction`),
+  `pkg/workflow/metadata.go` (`FunctionMetadata`, `ParameterSchema`);
+  `internal/packages/registry.go`, `loaded_package.go`, `internal_packages.go`;
+  `internal/handlers/packages.go` (REST API); transport in `internal/packages/transport/`.
+- Related: [ADR-0013](0013-workflow-schema-model-and-input-mapping.md),
+  [ADR-0015](0015-conditional-routing-with-expr-lang.md),
+  [ADR-0007](0007-agent-reasoning-loop-and-tools-from-functions.md),
+  [ADR-0016](0016-concurrency-and-rate-limiting.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,6 @@ copying [`template.md`](template.md).
 | 0019 | [Externalize large payloads to a pluggable object store](0019-object-store-payload-externalization.md) | Accepted | 2026-06-01 |
 | 0020 | [Observability: metrics, tracing, execution traces](0020-observability-metrics-tracing-execution-traces.md) | Accepted | 2026-06-01 |
 | 0021 | [Deployment and delivery architecture (CI/CD, Docker, Helm)](0021-deployment-and-delivery-architecture.md) | Accepted | 2026-06-01 |
+| 0022 | [Retry and error-handling model](0022-retry-and-error-handling-model.md)                 | Accepted | 2026-06-01 |
+| 0023 | [Timeout enforcement via actor timers](0023-timeout-enforcement-model.md)                | Accepted | 2026-06-01 |
+| 0024 | [Function packages: registry with declarative metadata](0024-package-registry-and-function-metadata.md) | Accepted | 2026-06-01 |


### PR DESCRIPTION
> **Draft / do not merge yet** — holding for an incoming Playwright-feature ADR from a concurrent session so we can reconcile ADR numbering (the Playwright ADR should take **0025**, after this batch). Mark ready once that's confirmed.

## Context

A code audit found ADRs 0001–0021 left the **execution-semantics** layer under-scoped: ADR-0010 records *that* steps happen, but not *how the engine behaves* on failure, on time limits, or how executable units are defined. This backfills the three clearly-worthy gaps, authored grounded in the verified code.

## ADRs (all Accepted, backfill)

- **0022 — Retry & error-handling model**: per-node `RetryPolicy` (fixed/exponential/linear backoff, `RetryTracker`) + first-class **error edges** (`OnError`), with the ordered fallback **retry → error-edge → fail-workflow** (`HandleNodeFailure`). Notes the duplicate-side-effect risk and the idempotency tie-in (0017).
- **0023 — Timeout enforcement**: node `TimeoutConfig` + workflow `GraphTimeoutConfig.Total`, enforced as **async ergo `SendAfter` timer messages** (`ExecutionTimer`, cancel-on-complete) rather than blocking/context cancellation — works for parked async steps; a fired timeout feeds the 0022 failure path.
- **0024 — Function packages: registry + declarative metadata**: functions as metadata-described units (`Package`/`FunctionMetadata`/`ParameterSchema`) in a `Registry`, the typed I/O contract behind node validation, conditional routing, the `/v1/packages` API, and agent tool-schema generation (0007). Notes in-process-only today; remote functions await the transport seam.

## Verification

- 3 files present; all index links + cross-ADR links resolve; no secrets; `go build ./...` unaffected (docs only).

## Numbering note for the concurrent session

This PR claims **0022–0024**. The Playwright ADR should be **0025** to avoid collision. If it already grabbed a number in [0022–0024], ping me and I'll renumber one side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)