### PR TITLE
feat(llm): native Anthropic provider (Phase C)

### DIFF
--- a/docs/adr/0006-llm-provider-abstraction-and-multi-provider-strategy.md
+++ b/docs/adr/0006-llm-provider-abstraction-and-multi-provider-strategy.md
@@ -86,6 +86,9 @@ substituted later without touching callers.
 - Code: `pkg/llm/` (interface + registry), `internal/llm/providers/openaicompat/`,
   `internal/app/di/llm.go`; config in `internal/app/config/config.go` (`LLMConfig`).
 - Shipped in PR #69 (Phase A).
+- Native **Anthropic** provider (Phase C): `internal/llm/providers/anthropic/` via
+  `anthropic-sdk-go`, registered under the `anthropic` key in `internal/app/di/llm.go`. Specified
+  under `specs/002-anthropic-provider/`. (Streaming and prompt caching remain Phase C follow-ups.)
 - Related: [ADR-0005](0005-ai-agents-as-workflow-nodes-phased-roadmap.md),
   [ADR-0007](0007-agent-reasoning-loop-and-tools-from-functions.md),
   [ADR-0008](0008-settings-environments-and-secrets-management.md).

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	ergo.services/ergo v1.999.320
 	ergo.services/registrar/etcd v0.2.0
 	github.com/TyphonHill/go-mermaid v1.0.0
+	github.com/anthropics/anthropic-sdk-go v1.46.0
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/expr-lang/expr v1.17.8
 	github.com/fatih/color v1.19.0
@@ -15,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/minio/minio-go/v7 v7.0.100
+	github.com/openai/openai-go/v3 v3.38.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.35.0
@@ -63,6 +65,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -76,12 +79,12 @@ require (
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openai/openai-go/v3 v3.38.0 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
+	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
 	github.com/sv-tools/openapi v0.4.0 // indirect
 	github.com/swaggo/files/v2 v2.0.0 // indirect
 	github.com/swaggo/swag v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/TyphonHill/go-mermaid v1.0.0 h1:VtmgQwgZA+KNHJvG/O591ibBVuDkGhg2+F/ol
 github.com/TyphonHill/go-mermaid v1.0.0/go.mod h1:BqMEbKnr2HHpZ4lJJvGjL47v6rZAUpJcOaE/db1Ppwc=
 github.com/agiledragon/gomonkey/v2 v2.3.1 h1:k+UnUY0EMNYUFUAQVETGY9uUTxjMdnUkP0ARyJS1zzs=
 github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
+github.com/anthropics/anthropic-sdk-go v1.46.0 h1:yl3n+el5ZfNgiCtQ7zQ7s/NXxB11YbrKXdc3uLPNWlU=
+github.com/anthropics/anthropic-sdk-go v1.46.0/go.mod h1:bx5vWuHFuGPkELH8Z4KUiNSohFnUwScdpTyr+50myPo=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -44,6 +46,8 @@ github.com/dhui/dktest v0.4.6 h1:+DPKyScKSEp3VLtbMDHcUq6V5Lm5zfZZVb0Sk7Ahom4=
 github.com/dhui/dktest v0.4.6/go.mod h1:JHTSYDtKkvFNFHJKqCzVzqXecyv+tKt8EzceOmQOgbU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
 github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -120,6 +124,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -206,6 +212,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 h1:uOfcYT+3QungH6tIGSVCR/Y3KJmgJiHcojJbMTPDZAI=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
@@ -332,6 +340,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/app/di/llm.go
+++ b/internal/app/di/llm.go
@@ -2,6 +2,7 @@ package di
 
 import (
 	"github.com/open-source-cloud/fuse/internal/app/config"
+	"github.com/open-source-cloud/fuse/internal/llm/providers/anthropic"
 	"github.com/open-source-cloud/fuse/internal/llm/providers/openaicompat"
 	"github.com/open-source-cloud/fuse/pkg/llm"
 	"github.com/rs/zerolog/log"
@@ -54,9 +55,15 @@ func provideLLMRegistry(cfg *config.Config) llm.Registry {
 		log.Info().Str("provider", p.name).Str("model", p.conf.Model).Msg("LLM provider registered")
 	}
 
-	// Anthropic (native protocol) is added in Phase C.
+	// Anthropic uses its own native protocol, so it has a separate implementation.
 	if cfg.LLM.Anthropic.Enabled {
-		log.Warn().Msg("LLM_ANTHROPIC_ENABLED is set but the Anthropic provider is not yet implemented (Phase C)")
+		providers[providerAnthropic] = anthropic.New(anthropic.Config{
+			Name:    providerAnthropic,
+			APIKey:  cfg.LLM.Anthropic.APIKey,
+			BaseURL: cfg.LLM.Anthropic.BaseURL,
+			Model:   cfg.LLM.Anthropic.Model,
+		})
+		log.Info().Str("provider", providerAnthropic).Str("model", cfg.LLM.Anthropic.Model).Msg("LLM provider registered")
 	}
 
 	if len(providers) == 0 {

--- a/internal/llm/providers/anthropic/provider.go
+++ b/internal/llm/providers/anthropic/provider.go
@@ -1,0 +1,222 @@
+// Package anthropic implements the llm.Provider interface against Anthropic's
+// native Messages API using anthropic-sdk-go. Unlike the OpenAI-compatible
+// providers, Anthropic carries the system prompt outside the message list and
+// represents tool calls/results as tool_use / tool_result content blocks.
+package anthropic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/open-source-cloud/fuse/pkg/llm"
+)
+
+// defaultMaxTokens is used when a request omits MaxTokens. Anthropic requires an
+// explicit maximum, unlike the OpenAI-compatible APIs.
+const defaultMaxTokens int64 = 4096
+
+// Config configures an Anthropic provider connection.
+type Config struct {
+	// Name is the registry key for this provider (i.e. "anthropic").
+	Name string
+	// APIKey is the Anthropic API key.
+	APIKey string
+	// BaseURL overrides the API endpoint (for gateways/proxies or tests). Empty
+	// uses the SDK default (api.anthropic.com).
+	BaseURL string
+	// Model is the default model used when a request does not specify one.
+	Model string
+}
+
+// Provider is an llm.Provider backed by the Anthropic Go SDK.
+type Provider struct {
+	name         string
+	defaultModel string
+	client       anthropic.Client
+}
+
+// New builds a Provider from cfg.
+func New(cfg Config) *Provider {
+	opts := make([]option.RequestOption, 0, 2)
+	if cfg.APIKey != "" {
+		opts = append(opts, option.WithAPIKey(cfg.APIKey))
+	}
+	if cfg.BaseURL != "" {
+		opts = append(opts, option.WithBaseURL(cfg.BaseURL))
+	}
+	return &Provider{
+		name:         cfg.Name,
+		defaultModel: cfg.Model,
+		client:       anthropic.NewClient(opts...),
+	}
+}
+
+// Name returns the provider's registry key.
+func (p *Provider) Name() string { return p.name }
+
+// Chat performs a message completion, translating to and from the Anthropic SDK types.
+func (p *Provider) Chat(ctx context.Context, req llm.ChatRequest) (llm.ChatResponse, error) {
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+	if model == "" {
+		return llm.ChatResponse{}, fmt.Errorf("anthropic[%s]: no model specified and no default configured", p.name)
+	}
+
+	system, messages := toAnthropicMessages(req.Messages)
+
+	params := anthropic.MessageNewParams{
+		Model:     model,
+		MaxTokens: resolveMaxTokens(req.MaxTokens),
+		Messages:  messages,
+		System:    system,
+	}
+	if len(req.Tools) > 0 {
+		params.Tools = toAnthropicTools(req.Tools)
+	}
+	if req.Temperature != nil {
+		params.Temperature = anthropic.Float(float64(*req.Temperature))
+	}
+	if tc, ok := toAnthropicToolChoice(req.ToolChoice); ok {
+		params.ToolChoice = tc
+	}
+
+	msg, err := p.client.Messages.New(ctx, params)
+	if err != nil {
+		return llm.ChatResponse{}, fmt.Errorf("anthropic[%s]: chat completion failed: %w", p.name, err)
+	}
+
+	return fromAnthropicMessage(msg), nil
+}
+
+// resolveMaxTokens returns the request's max tokens or the default.
+func resolveMaxTokens(reqMax *int) int64 {
+	if reqMax != nil && *reqMax > 0 {
+		return int64(*reqMax)
+	}
+	return defaultMaxTokens
+}
+
+// toAnthropicMessages splits the provider-agnostic messages into Anthropic's
+// separate system blocks and the user/assistant/tool message list.
+func toAnthropicMessages(messages []llm.Message) ([]anthropic.TextBlockParam, []anthropic.MessageParam) {
+	var system []anthropic.TextBlockParam
+	out := make([]anthropic.MessageParam, 0, len(messages))
+	for _, m := range messages {
+		switch m.Role {
+		case llm.RoleSystem:
+			if m.Content != "" {
+				system = append(system, anthropic.TextBlockParam{Text: m.Content})
+			}
+		case llm.RoleUser:
+			out = append(out, anthropic.NewUserMessage(anthropic.NewTextBlock(m.Content)))
+		case llm.RoleTool:
+			// Anthropic carries tool results in a user-role turn.
+			out = append(out, anthropic.NewUserMessage(anthropic.NewToolResultBlock(m.ToolCallID, m.Content, false)))
+		case llm.RoleAssistant:
+			out = append(out, toAnthropicAssistantMessage(m))
+		default:
+			out = append(out, anthropic.NewUserMessage(anthropic.NewTextBlock(m.Content)))
+		}
+	}
+	return system, out
+}
+
+// toAnthropicAssistantMessage builds an assistant message, carrying any tool calls
+// as tool_use content blocks alongside optional text.
+func toAnthropicAssistantMessage(m llm.Message) anthropic.MessageParam {
+	blocks := make([]anthropic.ContentBlockParamUnion, 0, len(m.ToolCalls)+1)
+	if m.Content != "" {
+		blocks = append(blocks, anthropic.NewTextBlock(m.Content))
+	}
+	for _, tc := range m.ToolCalls {
+		var input any = tc.Arguments
+		if len(tc.Arguments) == 0 {
+			input = map[string]any{}
+		}
+		blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, input, tc.Name))
+	}
+	return anthropic.NewAssistantMessage(blocks...)
+}
+
+// toAnthropicTools converts tool definitions to Anthropic tool params, extracting
+// the JSON-Schema "properties"/"required" from llm.Tool.Parameters.
+func toAnthropicTools(tools []llm.Tool) []anthropic.ToolUnionParam {
+	out := make([]anthropic.ToolUnionParam, 0, len(tools))
+	for _, t := range tools {
+		tool := anthropic.ToolParam{
+			Name: t.Name,
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Properties: t.Parameters["properties"],
+				Required:   toStringSlice(t.Parameters["required"]),
+			},
+		}
+		if t.Description != "" {
+			tool.Description = anthropic.String(t.Description)
+		}
+		out = append(out, anthropic.ToolUnionParam{OfTool: &tool})
+	}
+	return out
+}
+
+// toAnthropicToolChoice maps the agnostic tool-choice string to the SDK union.
+func toAnthropicToolChoice(choice string) (anthropic.ToolChoiceUnionParam, bool) {
+	switch choice {
+	case "auto":
+		return anthropic.ToolChoiceUnionParam{OfAuto: &anthropic.ToolChoiceAutoParam{}}, true
+	case "required":
+		return anthropic.ToolChoiceUnionParam{OfAny: &anthropic.ToolChoiceAnyParam{}}, true
+	default:
+		return anthropic.ToolChoiceUnionParam{}, false
+	}
+}
+
+// fromAnthropicMessage converts an SDK response message back to the agnostic type.
+func fromAnthropicMessage(msg *anthropic.Message) llm.ChatResponse {
+	out := llm.Message{Role: llm.RoleAssistant}
+	var content string
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			content += block.Text
+		case "tool_use":
+			out.ToolCalls = append(out.ToolCalls, llm.ToolCall{
+				ID:        block.ID,
+				Name:      block.Name,
+				Arguments: block.Input,
+			})
+		}
+	}
+	out.Content = content
+
+	return llm.ChatResponse{
+		Message:      out,
+		FinishReason: string(msg.StopReason),
+		Usage: llm.Usage{
+			PromptTokens:     int(msg.Usage.InputTokens),
+			CompletionTokens: int(msg.Usage.OutputTokens),
+			TotalTokens:      int(msg.Usage.InputTokens + msg.Usage.OutputTokens),
+		},
+	}
+}
+
+// toStringSlice coerces a JSON-Schema "required" value ([]string or []any) to []string.
+func toStringSlice(v any) []string {
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, e := range s {
+			if str, ok := e.(string); ok {
+				out = append(out, str)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/internal/llm/providers/anthropic/provider_test.go
+++ b/internal/llm/providers/anthropic/provider_test.go
@@ -1,0 +1,144 @@
+package anthropic_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/internal/llm/providers/anthropic"
+	"github.com/open-source-cloud/fuse/pkg/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newStubServer returns an httptest server that records the request body and
+// replies with respBody for any /v1/messages request.
+func newStubServer(t *testing.T, respBody string, captured *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if captured != nil {
+			_ = json.Unmarshal(body, captured)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, respBody)
+	}))
+}
+
+func TestProvider_Chat_ParsesTextResponse(t *testing.T) {
+	resp := `{
+		"id": "msg_1",
+		"type": "message",
+		"role": "assistant",
+		"model": "claude-test",
+		"content": [{"type":"text","text":"Hello there"}],
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 5, "output_tokens": 2}
+	}`
+	var captured map[string]any
+	srv := newStubServer(t, resp, &captured)
+	defer srv.Close()
+
+	p := anthropic.New(anthropic.Config{Name: "anthropic", APIKey: "test", BaseURL: srv.URL, Model: "claude-test"})
+	temp := float32(0.3)
+	out, err := p.Chat(context.Background(), llm.ChatRequest{
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: "be brief"},
+			{Role: llm.RoleUser, Content: "hi"},
+		},
+		Temperature: &temp,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Hello there", out.Message.Content)
+	assert.Equal(t, llm.RoleAssistant, out.Message.Role)
+	assert.Equal(t, "end_turn", out.FinishReason)
+	assert.Equal(t, 5, out.Usage.PromptTokens)
+	assert.Equal(t, 2, out.Usage.CompletionTokens)
+	assert.Equal(t, 7, out.Usage.TotalTokens)
+
+	// Request shape: default model, default max_tokens, system carried separately, temp forwarded.
+	assert.Equal(t, "claude-test", captured["model"])
+	assert.InDelta(t, 4096, captured["max_tokens"], 0.5, "default max_tokens supplied")
+	assert.InDelta(t, 0.3, captured["temperature"], 0.0001)
+
+	system, ok := captured["system"].([]any)
+	require.True(t, ok, "system carried as a separate field")
+	require.Len(t, system, 1)
+	assert.Equal(t, "be brief", system[0].(map[string]any)["text"])
+
+	msgs, ok := captured["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, msgs, 1, "system message is not in the messages list")
+	assert.Equal(t, "user", msgs[0].(map[string]any)["role"])
+}
+
+func TestProvider_Chat_ParsesToolUse(t *testing.T) {
+	resp := `{
+		"id": "msg_2",
+		"type": "message",
+		"role": "assistant",
+		"model": "claude-test",
+		"content": [{"type":"tool_use","id":"toolu_1","name":"http__request","input":{"path":"/x"}}],
+		"stop_reason": "tool_use",
+		"usage": {"input_tokens": 10, "output_tokens": 3}
+	}`
+	var captured map[string]any
+	srv := newStubServer(t, resp, &captured)
+	defer srv.Close()
+
+	p := anthropic.New(anthropic.Config{Name: "anthropic", APIKey: "test", BaseURL: srv.URL})
+	out, err := p.Chat(context.Background(), llm.ChatRequest{
+		Model:    "claude-test",
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "fetch"}},
+		Tools: []llm.Tool{{
+			Name:        "http__request",
+			Description: "make an http request",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"path": map[string]any{"type": "string"}},
+				"required":   []string{"path"},
+			},
+		}},
+		ToolChoice: "auto",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, out.Message.ToolCalls, 1)
+	tc := out.Message.ToolCalls[0]
+	assert.Equal(t, "toolu_1", tc.ID)
+	assert.Equal(t, "http__request", tc.Name)
+	assert.JSONEq(t, `{"path":"/x"}`, string(tc.Arguments))
+	assert.Equal(t, "tool_use", out.FinishReason)
+
+	// The request advertised the tool (with input_schema) and tool_choice=auto.
+	tools, ok := captured["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	tool := tools[0].(map[string]any)
+	assert.Equal(t, "http__request", tool["name"])
+	assert.Equal(t, "make an http request", tool["description"])
+	schema, ok := tool["input_schema"].(map[string]any)
+	require.True(t, ok)
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, props, "path")
+
+	choice, ok := captured["tool_choice"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "auto", choice["type"])
+}
+
+func TestProvider_Chat_NoModelErrors(t *testing.T) {
+	srv := newStubServer(t, `{}`, nil)
+	defer srv.Close()
+
+	p := anthropic.New(anthropic.Config{Name: "anthropic", APIKey: "test", BaseURL: srv.URL})
+	_, err := p.Chat(context.Background(), llm.ChatRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+	})
+	assert.Error(t, err)
+}

--- a/specs/002-anthropic-provider/checklists/requirements.md
+++ b/specs/002-anthropic-provider/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Native Anthropic LLM Provider
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-06-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately scopes out streaming and prompt caching (separate Phase C items) and
+  reuses the existing per-provider configuration shape, so no `[NEEDS CLARIFICATION]` markers were
+  needed. The behavioural contract mirrors the already-shipped OpenAI-compatible provider, which
+  bounds ambiguity.

--- a/specs/002-anthropic-provider/plan.md
+++ b/specs/002-anthropic-provider/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Native Anthropic LLM Provider
+
+**Branch**: `002-anthropic-provider` | **Date**: 2026-06-02 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/002-anthropic-provider/spec.md`
+
+## Summary
+
+Add `internal/llm/providers/anthropic` — an `llm.Provider` implementation backed by
+`anthropic-sdk-go` (v1.46.0) — and register it under the `anthropic` key. It mirrors the existing
+`openaicompat` provider's shape (a `Config` + `Provider` + `New` + `Chat`), translating the
+engine's provider-agnostic `llm.*` types to/from Anthropic's native Messages API (separate system
+field, `tool_use`/`tool_result` content blocks, `input_schema` tools). This completes the Phase C
+provider-breadth item in ADR-0006; the agent and chat nodes use it unchanged.
+
+## Technical Context
+
+**Language/Version**: Go 1.26  
+**Primary Dependencies**: `github.com/anthropics/anthropic-sdk-go v1.46.0` (new direct dep), behind
+the existing `pkg/llm` abstraction; uber-go/fx (DI), zerolog.  
+**Storage**: N/A.  
+**Testing**: `go test` / `gotestsum`; an `httptest` stub server pointed at via `option.WithBaseURL`
+(same pattern as `openaicompat/provider_test.go`), returning Anthropic-shaped JSON — no live key.  
+**Target Platform**: Linux server.  
+**Project Type**: single Go module.  
+**Performance Goals**: parity with existing providers; one network round-trip per `Chat`.  
+**Constraints**: no node-side or registry-interface changes (`llm.Provider` is the seam); no new
+config fields (the `anthropic` per-provider config already exists).  
+**Scale/Scope**: one new package (~1 file + test), a DI edit, a `go.mod` dep. Streaming and prompt
+caching are explicitly out of scope.
+
+## Constitution Check
+
+- **I. Test-First (NON-NEGOTIABLE)**: PASS — mapping is verified by table-driven tests against a
+  stub endpoint before/with implementation; target ≥90% on the provider's mapping logic (critical).
+- **II. Code Quality Gates (NON-NEGOTIABLE)**: PASS — `make lint && make build && make test`;
+  complexity ≤15 (translation factored into small `to*/from*` helpers like `openaicompat`).
+- **III. Go Best Practices**: PASS — implements the `llm.Provider` interface; wrapped errors with a
+  `anthropic[name]:` prefix; SDK-agnostic types stay in `pkg/llm`.
+- **IV–VIII**: PASS — no actor/DI/concurrency changes beyond registering one provider; the provider
+  is stateless and safe for concurrent `Chat` calls (the SDK client is concurrency-safe).
+
+**No violations.**
+
+## Project Structure
+
+```text
+internal/llm/providers/anthropic/
+├── provider.go        # NEW: Config, Provider, New, Chat + to/from mapping helpers
+└── provider_test.go   # NEW: stub-server table tests (text, tool_use, system split, usage, no-model error)
+
+internal/app/di/llm.go # MODIFY: register anthropic.New when enabled; remove the Phase C warning
+go.mod / go.sum        # MODIFY: promote anthropic-sdk-go to a direct dependency (go mod tidy)
+
+docs/adr/0006-...md     # MODIFY (minor): note the native Anthropic provider shipped
+```
+
+**Structure Decision**: New leaf package alongside `openaicompat`, selected by the DI registry.
+No change to `pkg/llm`, the registry interface, the config struct (the `anthropic` provider config
+already exists), or any node.
+
+## Phase 0 — Research
+
+See [research.md](research.md): the exact `anthropic-sdk-go` v1.46.0 API and the `llm.*` ↔ SDK
+mapping (system split, message/content blocks, tools + `input_schema`, tool_choice, response
+parsing, usage, required `max_tokens` default).
+
+## Phase 1 — Design
+
+No new entities or endpoints (the provider is reached through the existing
+`POST /v1/workflows/trigger`); no `data-model.md`/`contracts/` needed. Enabling Claude is covered in
+[quickstart.md](quickstart.md).
+
+## Complexity Tracking
+
+No constitution violations — table omitted.

--- a/specs/002-anthropic-provider/quickstart.md
+++ b/specs/002-anthropic-provider/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart: Using Claude via the Anthropic provider
+
+## Enable Anthropic
+
+```bash
+export LLM_ANTHROPIC_ENABLED=true
+export LLM_ANTHROPIC_API_KEY=sk-ant-...          # your Anthropic API key
+export LLM_ANTHROPIC_MODEL=claude-sonnet-4-5     # default model for this provider
+# optional: export LLM_ANTHROPIC_BASE_URL=https://your-gateway/   # proxy/gateway override
+# optional: make it the engine default
+export LLM_DEFAULT_PROVIDER=anthropic
+```
+
+## Use it from a node
+
+Any `ai/chat` or `ai/agent` node targets it with `"provider": "anthropic"` (or omit `provider` to
+use the default). No workflow or code change is needed beyond configuration:
+
+```json
+{ "input": "Use your tools to add 2 and 3.", "provider": "anthropic", "maxIterations": 5 }
+```
+
+Run the existing agent example against Claude:
+
+```bash
+make build && make run            # server on :9090
+curl -s -X POST localhost:9090/v1/workflows/trigger \
+  -H 'content-type: application/json' \
+  -d '{ "schemaId": "ai-agent-example", "input": {} }'
+curl -s localhost:9090/v1/workflows/<workflowID>/status | jq '.output, .steps'
+```
+
+## Fast unit feedback (no key, no server)
+
+```bash
+go test ./internal/llm/providers/anthropic/...
+```
+
+The stub-server tests verify request mapping (system split, tools, tool_choice) and response
+parsing (text, tool_use, usage) deterministically.

--- a/specs/002-anthropic-provider/research.md
+++ b/specs/002-anthropic-provider/research.md
@@ -1,0 +1,85 @@
+# Phase 0 Research: Native Anthropic Provider
+
+Verified against `github.com/anthropics/anthropic-sdk-go@v1.46.0` via `go doc`.
+
+## R1 — Client & call
+
+- `anthropic.NewClient(opts ...option.RequestOption) anthropic.Client` (value, like `openai`).
+  Options: `option.WithAPIKey`, `option.WithBaseURL`, `option.WithHeader`.
+- `client.Messages.New(ctx, anthropic.MessageNewParams{...}) (*anthropic.Message, error)`.
+- Mirror `openaicompat`: store `name`, `defaultModel`, `client`; resolve `model = req.Model ||
+  defaultModel`, error if empty (`anthropic[%s]: no model specified`).
+
+## R2 — Request params (`MessageNewParams`)
+
+- `Model Model` (`Model = string`) → set directly to the resolved model string.
+- `MaxTokens int64` is **required** (unlike OpenAI). Supply `anthropicDefaultMaxTokens = 4096` when
+  `req.MaxTokens` is nil; else use it. (FR-007)
+- `Temperature param.Opt[float64]` → `anthropic.Float(float64(*req.Temperature))` when set.
+- `System []TextBlockParam` → collect **all** `RoleSystem` messages into
+  `[]anthropic.TextBlockParam{{Text: <content>}}` (Anthropic carries system *outside* `messages`).
+- `Messages []MessageParam` → see R3.
+- `Tools []ToolUnionParam` → see R4.
+- `ToolChoice ToolChoiceUnionParam` → `"auto"` ⇒ `{OfAuto: &anthropic.ToolChoiceAutoParam{}}`;
+  `"required"` ⇒ `{OfAny: &anthropic.ToolChoiceAnyParam{}}`; else leave unset.
+
+## R3 — Message mapping (`llm.Message` → `MessageParam`)
+
+Iterate `req.Messages`, skipping `RoleSystem` (handled in R2):
+
+- `RoleUser` → `anthropic.NewUserMessage(anthropic.NewTextBlock(m.Content))`.
+- `RoleTool` (a tool result) → `anthropic.NewUserMessage(anthropic.NewToolResultBlock(m.ToolCallID,
+  m.Content, false))`. (Anthropic tool results live in a **user** turn.)
+- `RoleAssistant` → `anthropic.NewAssistantMessage(blocks...)` where blocks are: an optional
+  `NewTextBlock(m.Content)` (when non-empty) followed by one `NewToolUseBlock(tc.ID, tc.Arguments,
+  tc.Name)` per `m.ToolCalls` (the SDK marshals `tc.Arguments json.RawMessage` as the input).
+
+Constructors (stable, return `ContentBlockParamUnion`): `NewTextBlock(text)`,
+`NewToolUseBlock(id string, input any, name string)`, `NewToolResultBlock(toolUseID, content string,
+isError bool)`. `NewUserMessage`/`NewAssistantMessage(blocks ...ContentBlockParamUnion) MessageParam`.
+
+Anthropic auto-combines consecutive same-role turns, so emitting one user message per tool result
+is fine.
+
+## R4 — Tools (`llm.Tool` → `ToolUnionParam`)
+
+`llm.Tool.Parameters` is a full JSON-Schema object `{"type":"object","properties":{…},"required":
+[…]}`. Anthropic's `ToolInputSchemaParam` takes the **pieces** separately:
+
+```go
+anthropic.ToolUnionParam{OfTool: &anthropic.ToolParam{
+    Name:        t.Name,
+    Description: anthropic.String(t.Description), // when non-empty
+    InputSchema: anthropic.ToolInputSchemaParam{
+        Properties: t.Parameters["properties"],     // any (the properties object)
+        Required:   toStringSlice(t.Parameters["required"]), // []string
+    },
+}}
+```
+`Type` defaults to `"object"`. A small `toStringSlice` coerces `[]string` or `[]any` → `[]string`
+(our converter emits `[]string`).
+
+## R5 — Response parsing (`*anthropic.Message` → `llm.ChatResponse`)
+
+- `resp.Content []ContentBlockUnion`: switch on `block.Type`:
+  - `"text"` → append `block.Text` to the assistant content.
+  - `"tool_use"` → `llm.ToolCall{ID: block.ID, Name: block.Name, Arguments: json.RawMessage(block.Input)}`
+    (or `block.AsToolUse()`); `block.Input` is already `json.RawMessage`.
+- `FinishReason` = `string(resp.StopReason)` (`end_turn`, `tool_use`, `max_tokens`, …).
+- `Usage`: `PromptTokens = int(resp.Usage.InputTokens)`, `CompletionTokens =
+  int(resp.Usage.OutputTokens)`, `TotalTokens = Input + Output` (Anthropic reports no total).
+- Always return `Role: llm.RoleAssistant`.
+
+## R6 — Errors
+
+Wrap SDK errors as `fmt.Errorf("anthropic[%s]: chat completion failed: %w", name, err)`; an empty
+`resp.Content` is not itself an error (the agent handles an empty answer).
+
+## R7 — Test strategy (no live key)
+
+Mirror `openaicompat/provider_test.go`: `httptest.NewServer` returning Anthropic-shaped JSON,
+`anthropic.New(Config{BaseURL: srv.URL, APIKey: "test", Model: "claude-..."})`, and unmarshal the
+captured request body to assert the request shape (system array, messages, tools[].input_schema,
+tool_choice). Response fixtures: a text message and a `tool_use` message; assert parsed
+`ToolCall`, usage, and stop reason. Pass a dummy `APIKey` so the SDK sends auth headers without
+complaint.

--- a/specs/002-anthropic-provider/spec.md
+++ b/specs/002-anthropic-provider/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Native Anthropic LLM Provider
+
+**Feature Branch**: `002-anthropic-provider`  
+**Created**: 2026-06-02  
+**Status**: Draft  
+**Input**: User description: "Native Anthropic provider: implement the llm.Provider interface against Anthropic's native Messages API via anthropic-sdk-go, so agent and chat nodes can use Claude models. Completes the Phase C provider-breadth item from ADR-0006."
+
+## Clarifications
+
+### Session 2026-06-02
+
+- **Q: Default max output tokens when a request omits it?** → A: **4096** (Anthropic requires an
+  explicit `max_tokens`; the engine supplies this default unless the node sets one).
+- **Q: Default endpoint?** → A: the SDK default (`api.anthropic.com`), overridable via a base-URL
+  setting for proxies/gateways and tests.
+- **Q: Streaming / prompt caching in scope?** → A: **No** — separate Phase C items
+  ([ADR-0006](../../docs/adr/0006-llm-provider-abstraction-and-multi-provider-strategy.md)).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Use Claude from a chat node (Priority: P1)
+
+A workflow author who has an Anthropic API key configures the `anthropic` provider and points an
+`ai/chat` node at it (or makes it the default), and the node returns a Claude completion — through
+the exact same node configuration as any other provider.
+
+**Why this priority**: This is the core deliverable — Claude is a top-tier model family and the
+only one ADR-0006 left unimplemented. Without it, the provider abstraction's "any of five
+providers behind one interface" promise is incomplete.
+
+**Independent Test**: Configure `anthropic` (key + model), run a workflow whose chat node targets
+it, and confirm a text answer comes back with token usage populated.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `anthropic` provider is enabled with a key and model, **When** a chat node runs
+   against it, **Then** it returns the model's text answer and a token-usage summary.
+2. **Given** a node selects `provider: anthropic` while another provider is the default, **When**
+   it runs, **Then** the Anthropic provider is used.
+3. **Given** the provider call fails (bad key, model error), **When** the node runs, **Then** the
+   failure surfaces as a node error through normal error handling, not a crash.
+
+---
+
+### User Story 2 - Use Claude from an agent node with tools (Priority: P2)
+
+An author points an `ai/agent` node at `anthropic` and the agent's tool-calling reasoning loop
+works unchanged: Claude is offered the same tools, requests tool calls, receives tool results, and
+produces a final answer.
+
+**Why this priority**: Tool-calling parity is what makes the new provider useful for the agent
+(the headline Phase B feature), not just plain chat. It builds directly on P1.
+
+**Independent Test**: Run the existing agent example workflow with `provider: anthropic` against a
+stubbed/real endpoint and confirm a tool is invoked and a final answer returned — identical
+behaviour to an OpenAI-compatible provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent node using `anthropic` with at least one eligible tool, **When** it runs,
+   **Then** Claude can request a tool, the tool result is fed back, and a final answer is produced.
+2. **Given** the same workflow run on `anthropic` vs an OpenAI-compatible provider, **When** both
+   run, **Then** the agent's observable behaviour (tool calls, final output, usage) is equivalent.
+
+---
+
+### User Story 3 - Configure Anthropic like any other provider (Priority: P3)
+
+An operator enables, disables, and configures the Anthropic provider through the same per-provider
+configuration mechanism (enable flag, API key, model, optional base URL) as the existing
+providers, with predictable behaviour when it is not configured.
+
+**Why this priority**: Operational consistency; a refinement that makes the provider safe to ship
+with sensible defaults.
+
+**Independent Test**: Toggle the enable flag and confirm the provider appears/disappears from the
+registry; with it disabled, nodes targeting it get a clear "unknown provider" error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Anthropic enable flag is off, **When** the engine starts, **Then** the provider
+   is not registered and no "not implemented" warning is emitted.
+2. **Given** it is enabled, **When** the engine starts, **Then** it is registered under the
+   `anthropic` key and logged like the other providers.
+
+### Edge Cases
+
+- **No API key**: a clear configuration/auth error rather than a silent failure.
+- **No model**: if neither the node nor the provider config specifies a model, the provider fails
+  fast with a clear error (consistent with the OpenAI-compatible provider).
+- **No max tokens**: Anthropic requires `max_tokens`; the provider supplies a default so requests
+  that omit it still succeed.
+- **Multiple system messages / tool results**: translated correctly into Anthropic's separate
+  system field and tool_result blocks.
+- **Provider/network error**: surfaced as a node error, never a crash.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide an `anthropic` LLM provider, usable by `ai/chat` and
+  `ai/agent` through the same provider interface as the existing providers (no node-side changes).
+- **FR-002**: The provider MUST support Claude **tool calling** — advertise tools, receive
+  tool-use requests, and accept tool results — so the agent reasoning loop works unchanged.
+- **FR-003**: The provider MUST translate the engine's provider-agnostic messages (system, user,
+  assistant, tool) to and from Anthropic's native protocol, including its **separate system
+  field** and `tool_use` / `tool_result` content blocks.
+- **FR-004**: The provider MUST report token usage (input, output, and total) from Anthropic
+  responses.
+- **FR-005**: The provider MUST be enabled/disabled and configured (API key, model, optional base
+  URL) via the same per-provider configuration mechanism as the other providers, and be selectable
+  as the default provider.
+- **FR-006**: When enabled but a required setting is missing (no model and no per-request model),
+  the provider MUST fail with a clear error.
+- **FR-007**: Because Anthropic requires an explicit maximum output-token count, the provider MUST
+  supply a sensible default when a request omits it.
+- **FR-008**: Provider, model, and network errors MUST surface as errors to the calling node
+  (through normal error handling), never crashing the engine.
+- **FR-009**: When the Anthropic provider is disabled, the engine MUST NOT emit a
+  "not yet implemented" warning (that placeholder is removed once it is implemented).
+
+### Key Entities *(include if feature involves data)*
+
+- **Anthropic Provider**: a registered LLM provider (registry key `anthropic`) configured with an
+  API key, default model, and optional base URL; satisfies the same interface as other providers.
+- **Provider-agnostic message / tool / usage**: the existing engine types, mapped to/from
+  Anthropic's native request/response shapes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A chat node configured with `provider: anthropic` returns a Claude completion
+  end-to-end with no changes beyond configuration.
+- **SC-002**: An agent node using `anthropic` completes a tool-using task with the same observable
+  behaviour as the same workflow on an OpenAI-compatible provider.
+- **SC-003**: Token usage (input/output/total) is reported for Anthropic runs.
+- **SC-004**: Switching a workflow's provider between `anthropic` and another requires only
+  configuration — no workflow or code changes.
+- **SC-005**: Enabling/disabling the provider is a pure configuration change; disabled means
+  absent from the registry with no spurious warning.
+
+## Assumptions
+
+- **Default max output tokens**: 4096 when unspecified.
+- **Default endpoint**: the SDK default (`api.anthropic.com`); overridable via a base-URL setting.
+- **Out of scope**: streaming and prompt caching (separate Phase C items); these are not delivered
+  here.
+- **Configuration shape**: reuses the existing per-provider config (`enable`, `api key`, `model`,
+  `base url`) already present for `anthropic` in the config struct.

--- a/specs/002-anthropic-provider/tasks.md
+++ b/specs/002-anthropic-provider/tasks.md
@@ -1,0 +1,56 @@
+---
+description: "Task list for the native Anthropic LLM provider"
+---
+
+# Tasks: Native Anthropic LLM Provider
+
+**Input**: Design documents from `/specs/002-anthropic-provider/`
+**Prerequisites**: plan.md, spec.md, research.md
+
+**Tests**: REQUIRED (constitution: Test-First). Stub-server table tests, no live key.
+
+## Phase 1: Setup
+
+- [ ] T001 Add the dependency: `github.com/anthropics/anthropic-sdk-go@v1.46.0` (already fetched);
+  `go mod tidy` will promote it to a direct dependency once it is imported (T002).
+
+## Phase 2: Foundational — the provider (blocks the user stories)
+
+- [ ] T002 Create `internal/llm/providers/anthropic/provider.go`: `Config{Name, APIKey, BaseURL,
+  Model}`, `Provider{name, defaultModel, client}`, `New(cfg) *Provider` (build client via
+  `option.WithAPIKey/WithBaseURL`), `Name()`, and `Chat(ctx, llm.ChatRequest) (llm.ChatResponse,
+  error)` implementing the R1–R6 mapping (system split, message/tool blocks, tools + input_schema,
+  tool_choice, response parse, usage, default `max_tokens` = 4096). Factor `to*/from*` helpers to
+  keep complexity ≤15.
+- [ ] T003 [P] Create `internal/llm/providers/anthropic/provider_test.go` (mirror
+  `openaicompat/provider_test.go`): stub-server tests for (a) text response + usage + system/temp
+  request shape, (b) tool advertisement + `tool_use` parse + `tool_choice`, (c) no-model error.
+  (Test-first / alongside T002.)
+
+## Phase 3: US1 + US2 — wire it in (the provider is usable by chat & agent)
+
+- [ ] T004 [US1][US2] `internal/app/di/llm.go`: register `anthropic.New(...)` under the `anthropic`
+  key when `cfg.LLM.Anthropic.Enabled`, log like the other providers, and **remove** the
+  "not yet implemented (Phase C)" warning (FR-009). No registry/interface change.
+- [ ] T005 [US1] `go mod tidy` so `anthropic-sdk-go` is a direct dependency; `go build ./...`
+  confirms the fx graph still wires (no signature changes expected).
+
+## Phase 4: US3 — configuration parity
+
+- [ ] T006 [US3] Confirm the existing `LLM_ANTHROPIC_*` config (enable/api key/model/base url) flows
+  through unchanged; add a base-URL field only if missing. Verify disabled ⇒ absent from registry,
+  no warning (covered by reading config.go + a DI smoke check).
+
+## Phase 5: Polish
+
+- [ ] T007 [P] Minor ADR-0006 update: note the native Anthropic provider shipped (Phase C item).
+- [ ] T008 Quality gate: `make lint && make build && make test`; then commit, push, open PR.
+
+## Dependencies
+- T002 → T003 (test targets the provider) and → T004 (DI imports the package).
+- T004 → T005 (tidy/build) → T008.
+
+## Notes
+- The behavioural contract mirrors the shipped `openaicompat` provider; the agent/chat nodes and
+  the `llm.Provider`/registry interfaces are unchanged.
+- Out of scope: streaming, prompt caching (separate Phase C items).


### PR DESCRIPTION
## Summary

Adds a **native Anthropic LLM provider** so `ai/chat` and `ai/agent` can use Claude models — completing the Phase C provider-breadth item in [ADR-0006](docs/adr/0006-llm-provider-abstraction-and-multi-provider-strategy.md). The `openaicompat` provider already covered OpenAI/OpenRouter/Ollama/Gemini; Anthropic uses its own protocol, so it gets a dedicated implementation behind the same `llm.Provider` seam.

### What's included
- `internal/llm/providers/anthropic/provider.go` — `Config` + `Provider` + `New` + `Chat`, backed by `anthropic-sdk-go v1.46.0`, mapping the engine's provider-agnostic types to/from Anthropic's Messages API:
  - **system** prompt carried separately from the message list
  - user / assistant / **tool** turns, with `tool_use` and `tool_result` content blocks
  - tools advertised via `input_schema` (properties/required extracted from `llm.Tool.Parameters`)
  - `tool_choice` (`auto` / `required`), token `usage` (input/output/total), and `stop_reason`
  - a default `max_tokens` (4096) since Anthropic requires an explicit maximum
- `internal/app/di/llm.go` — registers the provider under the `anthropic` key when `LLM_ANTHROPIC_ENABLED`, and **removes** the old "not yet implemented (Phase C)" startup warning
- `internal/llm/providers/anthropic/provider_test.go` — stub-server tests (no live key): text response + request shape, `tool_use` parse + tool/`tool_choice` advertisement, and the no-model error
- Promotes `anthropic-sdk-go` to a direct dependency (`go mod tidy`)

### Out of scope
Streaming and prompt caching remain separate Phase C follow-ups.

### Notes
- **No changes** to `pkg/llm`, the registry interface, the config struct (the `anthropic` per-provider config already existed), or any node — switching a workflow to Claude is purely configuration (see `specs/002-anthropic-provider/quickstart.md`).

## Verification
- `make lint` → **0 issues** · `make build` → OK · `make test` → **620 tests pass**
- Provider mapping verified against the real SDK via an `httptest` stub (request shape + response parsing); no live API key needed
- Spec-driven artifacts under `specs/002-anthropic-provider/` (spec + clarifications, plan, research with the exact SDK mapping, quickstart, tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
