### PR TITLE
docs(adr): decide settings/secrets direction (ADR-0031), supersede 0008

### DIFF
--- a/docs/adr/0008-settings-environments-and-secrets-management.md
+++ b/docs/adr/0008-settings-environments-and-secrets-management.md
@@ -1,8 +1,14 @@
 # 0008. Settings, environments & secrets management
 
-- Status: Proposed — **decision DEFERRED**
+- Status: Superseded by [ADR-0031](0031-settings-secrets-and-environments.md)
 - Date: 2026-06-01
 - Deciders: FUSE maintainers
+
+> **Superseded:** this ADR recorded the problem and deferred the decision.
+> [ADR-0031](0031-settings-secrets-and-environments.md) makes the decision — a pluggable
+> `SecretStore` seam with secret references (Option A) as the foundation, credential objects
+> (B) and external backends (C) as layers, environment/workflow scoping, input-mapping-time
+> resolution, and mandatory redaction — with a phased roadmap.
 
 ## Context and Problem Statement
 

--- a/docs/adr/0031-settings-secrets-and-environments.md
+++ b/docs/adr/0031-settings-secrets-and-environments.md
@@ -1,0 +1,127 @@
+# 0031. Settings, secrets & environments: a SecretStore seam with secret references
+
+- Status: Accepted
+- Date: 2026-06-02
+- Deciders: FUSE maintainers
+
+## Context and Problem Statement
+
+[ADR-0008](0008-settings-environments-and-secrets-management.md) recorded the problem — every
+secret is a process-level env var parsed once at startup, the LLM provider registry is built once
+([ADR-0006](0006-llm-provider-abstraction-and-multi-provider-strategy.md)) so keys/base-URLs are
+fixed per process, there are no secret references in schemas, no per-context resolution, and no
+redaction — and then **deferred the decision**. With the agent roadmap shipping
+([ADR-0005](0005-ai-agents-as-workflow-nodes-phased-roadmap.md), 0007), the need is now concrete:
+different workflows / environments / tenants need different credentials (e.g. one tenant's OpenAI
+key vs another's, staging vs prod endpoints), and secrets must never be inlined in versioned
+schemas or leak into logs/journal/traces. This ADR **resolves 0008** by choosing an architecture
+and a phased path; it supersedes 0008. Implementation is phased and tracked separately (no code in
+this ADR).
+
+## Decision Drivers
+
+- **Dynamic, context-scoped resolution** — the right secret per workflow / environment / (future)
+  tenant / execution, not a single process-wide value.
+- **Reference, never inline** — schemas reference a secret by name; plaintext never appears in
+  graph JSON, the journal ([ADR-0010](0010-durable-execution-journal-and-replay.md)),
+  `aggregatedOutput`, logs, or traces ([ADR-0020](0020-observability-metrics-tracing-execution-traces.md)).
+- **Central management** — add / update / rotate without redeploying or restarting the engine.
+- **Pluggable backends** — in-memory/dev, a persisted (encrypted-at-rest) store, and external
+  managers, behind one seam.
+- **Least privilege & auditability** — a function receives only the resolved values it needs.
+- **Incremental & low-blast-radius** — fit the existing input pipeline; keep functions oblivious to
+  secrets; compose with a future multi-tenancy model rather than fight it.
+
+## Considered Options
+
+(Carried forward from ADR-0008.)
+
+- **A — Secret references + pluggable `SecretStore`, resolved at input-mapping time.** A typed
+  `SourceSecret` mapping (and/or a `{{secret:NAME}}` reference) that a `SecretStore` resolves while
+  building a node's input, scoped by the execution's context.
+- **B — n8n-style credentials registry.** First-class, typed credential objects ("OpenAI prod")
+  in a repository, referenced by id, injected at execution.
+- **C — External secrets manager** (Vault / Infisical / cloud KMS) behind a `SecretStore` interface.
+- **Cross-cutting — an explicit "environments" concept** (dev/staging/prod) as a scoping dimension.
+
+## Decision Outcome
+
+Chosen: **a layered architecture with Option A as the foundation**, because it satisfies the
+drivers with the smallest, most incremental change and gives B and C a stable seam to build on.
+
+1. **Foundation — `SecretStore` seam + typed secret references (A).** Introduce a `SecretStore`
+   port (`Resolve(ctx, scope, name) (SecretValue, error)`) and a new **`SourceSecret`** input
+   source (plus a `{{secret:NAME}}` reference form reusing the `ReplaceTokens` precedent in
+   `pkg/strutil`). The **engine resolves references at input-mapping time**
+   (`internal/workflow/edge_schema.go` / the input-mapping step), so a function receives
+   already-resolved values and **never sees the store**. This deliberately mirrors the principle
+   established by the ai/agent refactor ([ADR-0007](0007-agent-reasoning-loop-and-tools-from-functions.md)):
+   runtime capabilities are injected at the engine layer, **not** hung on the `ExecutionInfo`
+   input/output contract.
+2. **Credential objects (B) layer on the same seam, later.** Typed, centrally-managed credentials
+   referenced by id are a higher-level convenience implemented *over* `SecretStore` (a credential
+   resolves to one or more secrets); they are not a competing design.
+3. **External managers (C) are pluggable `SecretStore` backends.** Vault/Infisical/KMS implement
+   the same interface; they are custody/rotation backends *for* A/B, not a standalone answer.
+4. **Scoping = environment + workflow now, tenant-ready.** A resolution **scope** (environment
+   label + workflow id, extensible to tenant) is passed *into* `SecretStore.Resolve` — carried by
+   the engine, not stored on the function contract. An explicit **environment** concept
+   (dev/staging/prod) is the first scoping dimension.
+5. **Redaction is mandatory and part of the seam.** Resolved secrets are carried as a marked
+   `SecretValue` type so they render as `[REDACTED]` and are stripped before anything reaches
+   logs, the journal, traces, snapshots, or `aggregatedOutput`. A reference that is never resolved
+   never materializes a plaintext value anywhere persisted.
+6. **Provider keys (the agent driver) resolve via the same seam.** The static startup registry
+   ([ADR-0006](0006-llm-provider-abstraction-and-multi-provider-strategy.md)) remains the default;
+   per-context LLM keys/base-URLs resolve from `SecretStore`, which requires decoupling provider
+   construction from startup DI — recorded as a later phase, not done now.
+7. **Rotation & caching.** The store may cache with a TTL; resolution is per-execution so rotation
+   takes effect on the next run; values are stable within a single execution.
+
+### Phased roadmap
+
+- **Phase 1** — `SecretStore` interface + in-memory/dev backend; `SourceSecret` / `{{secret:NAME}}`
+  resolved at input mapping; the `SecretValue` redaction type wired through logging/journal/snapshots.
+- **Phase 2** — credential objects (B): typed credentials repository + CRUD API/UI, referenced by id.
+- **Phase 3** — external backends (C: Vault/Infisical/KMS), per-context LLM provider keys (dynamic
+  provider construction), and the explicit environments model.
+
+### Consequences
+
+- Good: a single seam unifies dev/persisted/external secrets; references keep plaintext out of
+  schemas; functions stay oblivious; the change is incremental and fits the existing input pipeline.
+- Good: composes cleanly with future multi-tenancy (scope already threads through `Resolve`).
+- Bad: resolution and redaction logic live in the engine's input/serialization layers and must be
+  audited carefully so no plaintext path is missed; redaction has to cover every sink.
+- Bad: per-context provider keys require decoupling provider construction from startup DI (Phase 3).
+- Neutral: a chosen direction, not a full implementation — Phases 2–3 remain to be scheduled.
+
+## Pros and Cons of the Options
+
+### A — SecretStore seam + references (chosen foundation)
+- Good: minimal, incremental, backend-agnostic; centralizes resolution + redaction at one point.
+- Bad: care needed that resolved values never get journaled/logged; "environments" still needs its
+  own scoping concept (addressed by the scope passed to `Resolve`).
+
+### B — Credentials registry (chosen as a later layer)
+- Good: familiar UX; reusable, typed, centrally managed; a natural audit boundary.
+- Bad: most new machinery (types, repo, CRUD, UI) — justified only once the seam (A) exists.
+
+### C — External secrets manager (chosen as a pluggable backend)
+- Good: enterprise rotation/audit/encryption-at-rest; offloads custody.
+- Bad: heavy dependency + operational burden; a backend *for* A/B, not standalone.
+
+## More Information
+
+- Supersedes [ADR-0008](0008-settings-environments-and-secrets-management.md) (which recorded the
+  problem and deferred the decision).
+- Current state this changes: `internal/app/config/config.go` (env-var secrets),
+  `internal/app/di/llm.go` (static-at-startup provider registry), `internal/workflow/edge_schema.go`
+  (`SourceSchema`/`SourceFlow` input mapping — gains `SourceSecret`), `pkg/strutil/strings.go`
+  (`ReplaceTokens` precedent), `pkg/workflow/execution_info.go` (stays a clean contract — no secret
+  field).
+- Related: [ADR-0005](0005-ai-agents-as-workflow-nodes-phased-roadmap.md) (agents drive per-context
+  secrets), [ADR-0006](0006-llm-provider-abstraction-and-multi-provider-strategy.md) (the static
+  registry this makes dynamic in Phase 3), [ADR-0013](0013-workflow-schema-model-and-input-mapping.md)
+  (the input-mapping model `SourceSecret` extends), [ADR-0010](0010-durable-execution-journal-and-replay.md)
+  / [ADR-0020](0020-observability-metrics-tracing-execution-traces.md) (sinks redaction must cover).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,7 +34,7 @@ copying [`template.md`](template.md).
 | 0005 | [AI agents as workflow nodes; phased roadmap](0005-ai-agents-as-workflow-nodes-phased-roadmap.md) | Accepted | 2026-06-01 |
 | 0006 | [LLM provider abstraction & multi-provider strategy](0006-llm-provider-abstraction-and-multi-provider-strategy.md) | Accepted | 2026-06-01 |
 | 0007 | [Agent reasoning loop & tools-from-functions](0007-agent-reasoning-loop-and-tools-from-functions.md) | Accepted | 2026-06-01 |
-| 0008 | [Settings, environments & secrets management](0008-settings-environments-and-secrets-management.md) | Proposed | 2026-06-01 |
+| 0008 | [Settings, environments & secrets management](0008-settings-environments-and-secrets-management.md) | Superseded by [0031](0031-settings-secrets-and-environments.md) | 2026-06-01 |
 | 0009 | [Portable AI agent guidance in `.agents/`](0009-portable-ai-agent-guidance.md)         | Accepted | 2026-06-01 |
 | 0010 | [Durable execution via an append-only journal](0010-durable-execution-journal-and-replay.md) | Accepted | 2026-06-01 |
 | 0011 | [Thread model for fork/join and ForEach](0011-threading-model-and-foreach.md)            | Accepted | 2026-06-01 |
@@ -57,3 +57,4 @@ copying [`template.md`](template.md).
 | 0028 | [Agent prompt/context & conversation-memory model](0028-agent-prompt-context-and-memory-model.md) | Proposed | 2026-06-02 |
 | 0029 | [LLM cost & token-usage tracking and budgets](0029-llm-cost-and-usage-tracking-and-budgets.md) | Proposed | 2026-06-02 |
 | 0030 | [Structured/JSON output enforcement for ai nodes](0030-structured-output-enforcement.md) | Proposed | 2026-06-02 |
+| 0031 | [Settings, secrets & environments: a SecretStore seam](0031-settings-secrets-and-environments.md) | Accepted | 2026-06-02 |


### PR DESCRIPTION
## Summary

Resolves the long-deferred settings/secrets decision. [ADR-0008](docs/adr/0008-settings-environments-and-secrets-management.md) recorded the problem (all secrets are process-wide startup env vars, the LLM registry is static per process, no secret references, no scoping, no redaction) and **deferred** the decision. **ADR-0031 decides it** and supersedes 0008.

### The decision (ADR-0031, Accepted)
- **Foundation — Option A**: a pluggable **`SecretStore` seam + typed secret references** (a new `SourceSecret` input source / `{{secret:NAME}}`), resolved by the engine **at input-mapping time** so functions receive already-resolved values and never see the store. (Mirrors the ai/agent-refactor principle: runtime capabilities are injected at the engine layer, not hung on the clean `ExecutionInfo` contract.)
- **Option B (credential objects)** layers on the same seam later; **Option C (Vault/Infisical/KMS)** are pluggable `SecretStore` backends — not competing designs.
- **Scoping**: environment + workflow now, tenant-ready (scope threads into `Resolve`, not the function contract).
- **Redaction is mandatory** and part of the seam — a marked `SecretValue` type keeps plaintext out of logs, the journal, traces, snapshots, and `aggregatedOutput`.
- **Provider keys** (the agent driver) resolve via the same seam later (Phase 3 decouples provider construction from startup DI).
- **Phased roadmap**: Phase 1 seam + refs + redaction → Phase 2 credential objects + CRUD/UI → Phase 3 external backends + per-context provider keys + environments.

This PR is **docs only** (no code) — it sets the architecture so the implementation phases can land incrementally.

### Changes
- `docs/adr/0031-settings-secrets-and-environments.md` (new, Accepted)
- `docs/adr/0008-…md` → **Superseded by 0031** (+ forward note)
- `docs/adr/README.md` — index updated (0008 superseded, 0031 added)

## Verification
- Index shows 0031 Accepted and 0008 Superseded; cross-links resolve.
- Records a concrete decision (seam + references + scoping + redaction + phased roadmap), not another deferral.
- Docs-only — `make lint/build/test` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
