### PR TITLE
feat(secrets): SecretStore seam + memory + encrypted-Postgres (ADR-0031 Phase 1)

### DIFF
--- a/docs/adr/0031-settings-secrets-and-environments.md
+++ b/docs/adr/0031-settings-secrets-and-environments.md
@@ -113,6 +113,14 @@ drivers with the smallest, most incremental change and gives B and C a stable se
 
 ## More Information
 
+- **Phase 1 shipped**: the `SecretStore` seam + `{{secret:NAME}}`/`source:"secret"` references
+  (resolved in `internal/workflow/workflow.go` `inputMapping`), AES-256-GCM redaction via
+  `pkg/secrets` (`SecretValue` → `***` everywhere; `FunctionInput.GetStr` reveals plaintext), the
+  **memory** + **encrypted-Postgres** backends (`pkg/secrets/memory.go`,
+  `internal/repositories/postgres/secret.go` + migration `000008_create_secrets`), the
+  `SECRETS_DRIVER` selection (`internal/app/di/secrets.go`), and the `fuse secrets` CLI. Infisical
+  (Phase 1's read-only external backend) is a fast-follow; credential objects (Phase 2) and
+  per-context provider keys (Phase 3) remain scheduled.
 - Supersedes [ADR-0008](0008-settings-environments-and-secrets-management.md) (which recorded the
   problem and deferred the decision).
 - Current state this changes: `internal/app/config/config.go` (env-var secrets),

--- a/internal/actors/workflow_handler.go
+++ b/internal/actors/workflow_handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-source-cloud/fuse/internal/messaging"
 	"github.com/open-source-cloud/fuse/internal/repositories"
 	"github.com/open-source-cloud/fuse/pkg/objectstore"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
 	"github.com/open-source-cloud/fuse/pkg/workflow"
 )
 
@@ -43,6 +44,7 @@ func NewWorkflowHandlerFactory(
 	eventBus events.EventBus,
 	fuseMetrics *metrics.FuseMetrics,
 	tracingProvider *tracing.Provider,
+	secretResolver secrets.Resolver,
 ) *WorkflowHandlerFactory {
 	return &WorkflowHandlerFactory{
 		Factory: func() gen.ProcessBehavior {
@@ -57,6 +59,7 @@ func NewWorkflowHandlerFactory(
 				eventBus:           eventBus,
 				fuseMetrics:        fuseMetrics,
 				tracingProvider:    tracingProvider,
+				secretResolver:     secretResolver,
 			}
 		},
 	}
@@ -77,6 +80,7 @@ type (
 		eventBus           events.EventBus
 		fuseMetrics        *metrics.FuseMetrics
 		tracingProvider    *tracing.Provider
+		secretResolver     secrets.Resolver
 
 		workflow       *internalworkflow.Workflow
 		executionTimer *ExecutionTimer
@@ -119,6 +123,7 @@ func (a *WorkflowHandler) Init(args ...any) error {
 
 	if a.workflowRepository.Exists(initArgs.workflowID.String()) {
 		a.workflow, _ = a.workflowRepository.Get(initArgs.workflowID.String())
+		a.workflow.SetSecretResolver(a.secretResolver)
 		if err := a.graphService.EnsureNodeMetadata(a.workflow.Graph()); err != nil {
 			a.Log().Error("failed to populate graph node metadata for workflow %s: %s", initArgs.workflowID, err)
 			return gen.TerminateReasonPanic
@@ -151,6 +156,7 @@ func (a *WorkflowHandler) Init(args ...any) error {
 		return gen.TerminateReasonPanic
 	}
 	a.workflow = internalworkflow.New(initArgs.workflowID, graphRef)
+	a.workflow.SetSecretResolver(a.secretResolver)
 	if a.workflowRepository.Save(a.workflow) != nil {
 		a.Log().Error("failed to save workflow for id %s: %s", initArgs.workflowID, err)
 		return nil

--- a/internal/app/cli/root.go
+++ b/internal/app/cli/root.go
@@ -50,6 +50,7 @@ func newRoot() *cobra.Command {
 	rootCmd.AddCommand(newServerCommand())
 	rootCmd.AddCommand(newMigrateCommand())
 	rootCmd.AddCommand(newSeedCommand())
+	rootCmd.AddCommand(newSecretsCommand())
 	rootCmd.AddCommand(newWorkflowCommand())
 	rootCmd.AddCommand(newMermaidCommand())
 	rootCmd.AddCommand(newHealthCommand())

--- a/internal/app/cli/secrets.go
+++ b/internal/app/cli/secrets.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/open-source-cloud/fuse/internal/app/config"
+	"github.com/open-source-cloud/fuse/internal/app/di"
+	"github.com/open-source-cloud/fuse/internal/logging"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+// secretsEnvFlag scopes secret operations to an environment (defaults to FUSE_ENVIRONMENT).
+var secretsEnvFlag string
+
+func newSecretsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secrets",
+		Short: "Manage secrets in the configured store",
+		Long: "Set, list, and delete secrets in the SECRETS_DRIVER backend. With driver=postgres " +
+			"values are AES-256-GCM encrypted at rest. The memory driver is per-process (use " +
+			"FUSE_SECRET_<NAME> env vars to seed the server instead).",
+	}
+	cmd.PersistentFlags().StringVar(&secretsEnvFlag, "env", "", "Environment scope (defaults to FUSE_ENVIRONMENT)")
+	cmd.AddCommand(newSecretsSetCommand(), newSecretsListCommand(), newSecretsDeleteCommand())
+	return cmd
+}
+
+func newSecretsSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <name> <value>",
+		Short: "Set (or rotate) a secret",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name, value := args[0], args[1]
+			return runSecretsApp(func(ctx context.Context, store secrets.ManagedSecretStore, env string) error {
+				if err := store.Set(ctx, secrets.Scope{Environment: env}, name, value); err != nil {
+					return err
+				}
+				log.Info().Str("environment", env).Str("name", name).Msg("secret set")
+				return nil
+			})
+		},
+	}
+}
+
+func newSecretsListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List secret names in an environment",
+		Args:  cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return runSecretsApp(func(ctx context.Context, store secrets.ManagedSecretStore, env string) error {
+				names, err := store.List(ctx, env)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("secrets in environment %q:\n", env)
+				if len(names) == 0 {
+					fmt.Println("  (none)")
+				}
+				for _, n := range names {
+					fmt.Printf("  - %s\n", n)
+				}
+				return nil
+			})
+		},
+	}
+}
+
+func newSecretsDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a secret",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := args[0]
+			return runSecretsApp(func(ctx context.Context, store secrets.ManagedSecretStore, env string) error {
+				if err := store.Delete(ctx, secrets.Scope{Environment: env}, name); err != nil {
+					return err
+				}
+				log.Info().Str("environment", env).Str("name", name).Msg("secret deleted")
+				return nil
+			})
+		},
+	}
+}
+
+// runSecretsApp boots the minimal DI graph (config + database + secrets), runs the
+// admin action against a managed store, and exits. It requires a ManagedSecretStore
+// (the memory and postgres backends qualify; a read-only backend does not).
+func runSecretsApp(action func(context.Context, secrets.ManagedSecretStore, string) error) error {
+	var actionErr error
+	app := fx.New(
+		di.CommonModule,
+		di.DatabaseModule,
+		di.SecretsModule,
+		fx.Invoke(func(lc fx.Lifecycle, cfg *config.Config, store secrets.SecretStore, sd fx.Shutdowner) {
+			lc.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					managed, ok := store.(secrets.ManagedSecretStore)
+					if !ok {
+						actionErr = errors.New("the configured SECRETS_DRIVER is read-only; set/list/delete require driver=memory or driver=postgres")
+					} else {
+						env := secretsEnvFlag
+						if env == "" {
+							env = cfg.Environment
+						}
+						actionErr = action(ctx, managed, env)
+					}
+					go func() { _ = sd.Shutdown() }()
+					return nil
+				},
+			})
+		}),
+		fx.WithLogger(logging.NewFxLogger()),
+	)
+	app.Run()
+	if err := app.Err(); err != nil {
+		return err
+	}
+	return actionErr
+}

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -24,6 +24,7 @@ type (
 	// Config represents the application configuration.
 	Config struct {
 		Name        string `env:"APP_NAME"`
+		Environment string `env:"FUSE_ENVIRONMENT" envDefault:"default"`
 		Params      ParamsConfig
 		Server      ServerConfig
 		Cluster     ClusterConfig
@@ -33,6 +34,19 @@ type (
 		Idempotency IdempotencyConfig
 		Otel        OtelConfig
 		LLM         LLMConfig
+		Secrets     SecretsConfig
+	}
+
+	// SecretsConfig configures the secret store backend (ADR-0031). Schemas
+	// reference secrets by name; the engine resolves them per environment at
+	// input-mapping time and redacts them from all sinks.
+	SecretsConfig struct {
+		// Driver selects the backend: "memory" (default, dev) or "postgres"
+		// (encrypted at rest). Infisical is added in a follow-up.
+		Driver string `env:"SECRETS_DRIVER" envDefault:"memory"`
+		// EncryptionKey is a base64-encoded 32-byte AES-256 key; required for the
+		// postgres driver.
+		EncryptionKey string `env:"SECRETS_ENCRYPTION_KEY"`
 	}
 
 	// LLMConfig configures the available LLM provider connections. Each provider

--- a/internal/app/di/di.go
+++ b/internal/app/di/di.go
@@ -63,6 +63,7 @@ var FuseAppModule = fx.Module(
 var AllModules = fx.Options(
 	CommonModule,
 	LLMModule,
+	SecretsModule,
 	PackageModule,
 	DatabaseModule,
 	ObjectStoreModule,

--- a/internal/app/di/secrets.go
+++ b/internal/app/di/secrets.go
@@ -1,0 +1,55 @@
+package di
+
+import (
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-source-cloud/fuse/internal/app/config"
+	"github.com/open-source-cloud/fuse/internal/repositories/postgres"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/rs/zerolog/log"
+	"go.uber.org/fx"
+)
+
+// SecretsModule provides the SecretStore (selected by SECRETS_DRIVER) and the
+// narrow Resolver the workflow engine uses to resolve secret references.
+var SecretsModule = fx.Module(
+	"secrets",
+	fx.Provide(
+		provideSecretStore,
+		provideSecretResolver,
+	),
+)
+
+type secretStoreParams struct {
+	fx.In
+	Config *config.Config
+	Pool   *pgxpool.Pool `optional:"true"`
+}
+
+// provideSecretStore selects the secret backend by SECRETS_DRIVER, mirroring the
+// object-store driver pattern. Postgres encrypts at rest (AES-256-GCM); it falls
+// back to memory (with a warning) if no DB pool is available.
+func provideSecretStore(p secretStoreParams) (secrets.SecretStore, error) {
+	switch p.Config.Secrets.Driver {
+	case "postgres":
+		if p.Pool == nil {
+			log.Warn().Msg("SECRETS_DRIVER=postgres but no database pool; falling back to the memory secret store")
+			return secrets.NewMemorySecretStoreFromEnv(p.Config.Environment), nil
+		}
+		cipher, err := secrets.NewCipherFromBase64Key(p.Config.Secrets.EncryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("%w (set SECRETS_ENCRYPTION_KEY to a base64-encoded 32-byte key)", err)
+		}
+		log.Info().Str("environment", p.Config.Environment).Msg("using postgres (encrypted) secret store")
+		return postgres.NewSecretStore(p.Pool, cipher), nil
+	default:
+		log.Debug().Str("environment", p.Config.Environment).Msg("using memory secret store")
+		return secrets.NewMemorySecretStoreFromEnv(p.Config.Environment), nil
+	}
+}
+
+// provideSecretResolver binds the store + configured environment into a Resolver.
+func provideSecretResolver(store secrets.SecretStore, cfg *config.Config) secrets.Resolver {
+	return secrets.NewResolver(store, cfg.Environment)
+}

--- a/internal/repositories/postgres/migrations/000008_create_secrets.down.sql
+++ b/internal/repositories/postgres/migrations/000008_create_secrets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS secrets;

--- a/internal/repositories/postgres/migrations/000008_create_secrets.up.sql
+++ b/internal/repositories/postgres/migrations/000008_create_secrets.up.sql
@@ -1,0 +1,17 @@
+-- ADR-0031 Phase 1: encrypted-at-rest secret store.
+-- Values are AES-256-GCM encrypted by the application before being stored here;
+-- the encrypted_value column only ever holds ciphertext (nonce-prefixed).
+
+CREATE TABLE secrets (
+    id              BIGSERIAL    PRIMARY KEY,
+    environment     VARCHAR(128) NOT NULL,
+    name            VARCHAR(255) NOT NULL,
+    encrypted_value BYTEA        NOT NULL,
+    source          VARCHAR(50)  NOT NULL DEFAULT 'manual',
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_secrets_env_name UNIQUE (environment, name)
+);
+
+CREATE INDEX idx_secrets_environment ON secrets (environment);

--- a/internal/repositories/postgres/secret.go
+++ b/internal/repositories/postgres/secret.go
@@ -1,0 +1,92 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+)
+
+// SecretStore is an encrypted-at-rest secrets.ManagedSecretStore backed by
+// PostgreSQL. Values are AES-256-GCM encrypted on write and decrypted on read;
+// the database column only ever holds ciphertext.
+type SecretStore struct {
+	pool   *pgxpool.Pool
+	cipher *secrets.Cipher
+}
+
+// compile-time assertion.
+var _ secrets.ManagedSecretStore = (*SecretStore)(nil)
+
+// NewSecretStore creates a PostgreSQL-backed encrypted secret store.
+func NewSecretStore(pool *pgxpool.Pool, cipher *secrets.Cipher) *SecretStore {
+	return &SecretStore{pool: pool, cipher: cipher}
+}
+
+// Resolve decrypts and returns the secret for (environment, name).
+func (r *SecretStore) Resolve(ctx context.Context, scope secrets.Scope, name string) (secrets.SecretValue, error) {
+	var enc []byte
+	err := r.pool.QueryRow(ctx,
+		`SELECT encrypted_value FROM secrets WHERE environment = $1 AND name = $2`,
+		scope.Environment, name,
+	).Scan(&enc)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return secrets.SecretValue{}, fmt.Errorf("%w: %q (environment %q)", secrets.ErrSecretNotFound, name, scope.Environment)
+		}
+		return secrets.SecretValue{}, fmt.Errorf("postgres/secrets: query: %w", err)
+	}
+	plaintext, err := r.cipher.Decrypt(enc)
+	if err != nil {
+		return secrets.SecretValue{}, fmt.Errorf("postgres/secrets: decrypt %q: %w", name, err)
+	}
+	return secrets.NewSecretValue(string(plaintext)), nil
+}
+
+// Set encrypts and upserts a secret value.
+func (r *SecretStore) Set(ctx context.Context, scope secrets.Scope, name, value string) error {
+	enc, err := r.cipher.Encrypt([]byte(value))
+	if err != nil {
+		return fmt.Errorf("postgres/secrets: encrypt %q: %w", name, err)
+	}
+	_, err = r.pool.Exec(ctx,
+		`INSERT INTO secrets (environment, name, encrypted_value, source, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'manual', NOW(), NOW())
+		 ON CONFLICT (environment, name)
+		 DO UPDATE SET encrypted_value = EXCLUDED.encrypted_value, updated_at = NOW()`,
+		scope.Environment, name, enc,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres/secrets: upsert %q: %w", name, err)
+	}
+	return nil
+}
+
+// List returns the secret names in an environment, sorted.
+func (r *SecretStore) List(ctx context.Context, environment string) ([]string, error) {
+	rows, err := r.pool.Query(ctx, `SELECT name FROM secrets WHERE environment = $1 ORDER BY name`, environment)
+	if err != nil {
+		return nil, fmt.Errorf("postgres/secrets: list: %w", err)
+	}
+	defer rows.Close()
+
+	names := make([]string, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("postgres/secrets: scan: %w", err)
+		}
+		names = append(names, name)
+	}
+	return names, rows.Err()
+}
+
+// Delete removes a secret.
+func (r *SecretStore) Delete(ctx context.Context, scope secrets.Scope, name string) error {
+	if _, err := r.pool.Exec(ctx, `DELETE FROM secrets WHERE environment = $1 AND name = $2`, scope.Environment, name); err != nil {
+		return fmt.Errorf("postgres/secrets: delete %q: %w", name, err)
+	}
+	return nil
+}

--- a/internal/workflow/edge_schema.go
+++ b/internal/workflow/edge_schema.go
@@ -17,6 +17,10 @@ const (
 	SourceSchema InputMappingSource = "schema"
 	// SourceFlow source data from workflow
 	SourceFlow InputMappingSource = "flow"
+	// SourceSecret resolves a secret by name (held in Variable) via the SecretStore,
+	// scoped by the workflow's environment. The resolved value is redacted in every
+	// engine sink (ADR-0031).
+	SourceSecret InputMappingSource = "secret"
 )
 
 type (

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -2,6 +2,7 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/open-source-cloud/fuse/internal/workflow/workflowactions"
 
 	"github.com/open-source-cloud/fuse/internal/typeschema"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
 	"github.com/open-source-cloud/fuse/pkg/store"
 	"github.com/open-source-cloud/fuse/pkg/strutil"
 	"github.com/open-source-cloud/fuse/pkg/workflow"
@@ -63,6 +65,48 @@ func New(id workflow.ID, graph *Graph) *Workflow {
 	}
 }
 
+// SetSecretResolver injects the secret resolver used to resolve {{secret:NAME}}
+// references and source:"secret" mappings during input mapping. The actor calls
+// this at Init on both the new and replay paths, since the resolver is a runtime
+// dependency that is not persisted with the workflow.
+func (w *Workflow) SetSecretResolver(r secrets.Resolver) {
+	w.secretResolver = r
+}
+
+// resolveSchemaValue resolves any {{secret:NAME}} references embedded in a schema
+// string value, wrapping the whole result as a SecretValue so it is redacted in
+// every sink. Non-string or reference-free values pass through unchanged.
+func (w *Workflow) resolveSchemaValue(value any) (any, error) {
+	s, ok := value.(string)
+	if !ok || !secrets.HasSecretRef(s) {
+		return value, nil
+	}
+	resolved, err := secrets.ReplaceSecretRefs(s, func(name string) (string, error) {
+		sv, err := w.secretValueByName(name)
+		if err != nil {
+			return "", err
+		}
+		return sv.Reveal(), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return secrets.NewSecretValue(resolved), nil
+}
+
+// resolveSecret resolves a SourceSecret mapping (the secret name) to a SecretValue.
+func (w *Workflow) resolveSecret(name string) (secrets.SecretValue, error) {
+	return w.secretValueByName(name)
+}
+
+// secretValueByName resolves a secret by name, scoped to this workflow's environment.
+func (w *Workflow) secretValueByName(name string) (secrets.SecretValue, error) {
+	if w.secretResolver == nil {
+		return secrets.SecretValue{}, fmt.Errorf("secret %q referenced but no secret store is configured", name)
+	}
+	return w.secretResolver.Resolve(context.Background(), string(w.id), name)
+}
+
 type (
 	// Workflow defines a Workflow
 	Workflow struct {
@@ -74,6 +118,10 @@ type (
 		threads          *threads
 		aggregatedOutput *store.KV
 		state            RunningState
+		// secretResolver resolves secret references during input mapping. It is a
+		// non-serializable runtime dependency injected by the actor at Init (set on
+		// both the new and replay paths); nil when no secret store is wired.
+		secretResolver secrets.Resolver
 	}
 
 	// RunningState defines the Workflow running state
@@ -611,7 +659,21 @@ func (w *Workflow) inputMapping(edge *Edge, mappings []InputMapping) map[string]
 					Msg(logMsgFailedParamValidation)
 				continue
 			}
-			args.Set(mapping.MapTo, mapping.Value)
+			value, err := w.resolveSchemaValue(mapping.Value)
+			if err != nil {
+				log.Error().Err(err).Str("edge", edge.ID()).Str("param", mapping.MapTo).
+					Msg("failed to resolve secret reference")
+				continue
+			}
+			args.Set(mapping.MapTo, value)
+		case SourceSecret:
+			sv, err := w.resolveSecret(mapping.Variable)
+			if err != nil {
+				log.Error().Err(err).Str("edge", edge.ID()).Str("param", mapping.MapTo).
+					Str("secret", mapping.Variable).Msg("failed to resolve secret")
+				continue
+			}
+			args.Set(mapping.MapTo, sv)
 		case SourceFlow:
 			outputParamName := strutil.AfterFirstDot(mapping.Variable)
 

--- a/internal/workflow/workflow_secret_test.go
+++ b/internal/workflow/workflow_secret_test.go
@@ -1,0 +1,48 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflow_ResolveSecretReferences(t *testing.T) {
+	store := secrets.NewMemorySecretStore()
+	require.NoError(t, store.Set(context.Background(), secrets.Scope{Environment: "test"}, "tok", "T0KEN"))
+
+	w := &Workflow{id: workflow.ID("wf-1")}
+	w.SetSecretResolver(secrets.NewResolver(store, "test"))
+
+	// {{secret:NAME}} embedded in a schema string -> a SecretValue wrapping the whole value.
+	v, err := w.resolveSchemaValue("Bearer {{secret:tok}}")
+	require.NoError(t, err)
+	sv, ok := v.(secrets.SecretValue)
+	require.True(t, ok)
+	assert.Equal(t, "Bearer T0KEN", sv.Reveal())
+	b, _ := json.Marshal(sv)
+	assert.JSONEq(t, `"***"`, string(b))
+
+	// A reference-free value passes through unchanged.
+	v, err = w.resolveSchemaValue("plain")
+	require.NoError(t, err)
+	assert.Equal(t, "plain", v)
+
+	// source:"secret" resolves to a SecretValue.
+	sv2, err := w.resolveSecret("tok")
+	require.NoError(t, err)
+	assert.Equal(t, "T0KEN", sv2.Reveal())
+
+	// An unknown secret surfaces the not-found error.
+	_, err = w.resolveSecret("missing")
+	assert.ErrorIs(t, err, secrets.ErrSecretNotFound)
+
+	// With no resolver configured, a secret reference is an error.
+	wNoResolver := &Workflow{id: workflow.ID("wf-2")}
+	_, err = wNoResolver.resolveSecret("tok")
+	assert.Error(t, err)
+}

--- a/pkg/secrets/crypto.go
+++ b/pkg/secrets/crypto.go
@@ -1,0 +1,59 @@
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Cipher encrypts and decrypts secret values with AES-256-GCM.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// NewCipherFromBase64Key builds a Cipher from a base64-encoded 32-byte (256-bit) key.
+func NewCipherFromBase64Key(b64 string) (*Cipher, error) {
+	key, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: decode encryption key: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("secrets: encryption key must be 32 bytes (got %d)", len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: new cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: new gcm: %w", err)
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+// Encrypt returns nonce-prefixed ciphertext.
+func (c *Cipher) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("secrets: generate nonce: %w", err)
+	}
+	return c.aead.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Decrypt reverses Encrypt over nonce-prefixed ciphertext.
+func (c *Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
+	nonceSize := c.aead.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, errors.New("secrets: ciphertext too short")
+	}
+	nonce, ct := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := c.aead.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: decrypt: %w", err)
+	}
+	return plaintext, nil
+}

--- a/pkg/secrets/memory.go
+++ b/pkg/secrets/memory.go
@@ -1,0 +1,87 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// envSecretPrefix seeds the memory store from FUSE_SECRET_<NAME>=<value> env vars
+// into the default environment.
+const envSecretPrefix = "FUSE_SECRET_"
+
+// MemorySecretStore is an in-memory ManagedSecretStore for dev and testing.
+type MemorySecretStore struct {
+	mu   sync.RWMutex
+	data map[string]map[string]string // environment -> name -> value
+}
+
+// NewMemorySecretStore creates an empty store.
+func NewMemorySecretStore() *MemorySecretStore {
+	return &MemorySecretStore{data: make(map[string]map[string]string)}
+}
+
+// NewMemorySecretStoreFromEnv seeds from FUSE_SECRET_* env vars into defaultEnv.
+func NewMemorySecretStoreFromEnv(defaultEnv string) *MemorySecretStore {
+	s := NewMemorySecretStore()
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, envSecretPrefix) {
+			continue
+		}
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		name := strings.TrimPrefix(kv[:eq], envSecretPrefix)
+		_ = s.Set(context.Background(), Scope{Environment: defaultEnv}, name, kv[eq+1:])
+	}
+	return s
+}
+
+// Resolve returns the secret for (environment, name) or ErrSecretNotFound.
+func (s *MemorySecretStore) Resolve(_ context.Context, scope Scope, name string) (SecretValue, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if env, ok := s.data[scope.Environment]; ok {
+		if v, ok := env[name]; ok {
+			return NewSecretValue(v), nil
+		}
+	}
+	return SecretValue{}, fmt.Errorf("%w: %q (environment %q)", ErrSecretNotFound, name, scope.Environment)
+}
+
+// Set stores (or replaces) a secret value.
+func (s *MemorySecretStore) Set(_ context.Context, scope Scope, name, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.data[scope.Environment] == nil {
+		s.data[scope.Environment] = make(map[string]string)
+	}
+	s.data[scope.Environment][name] = value
+	return nil
+}
+
+// List returns the secret names in an environment, sorted.
+func (s *MemorySecretStore) List(_ context.Context, environment string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.data[environment]))
+	for k := range s.data[environment] {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Delete removes a secret.
+func (s *MemorySecretStore) Delete(_ context.Context, scope Scope, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if env, ok := s.data[scope.Environment]; ok {
+		delete(env, name)
+	}
+	return nil
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,118 @@
+package secrets_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretValue_Redaction(t *testing.T) {
+	t.Parallel()
+	sv := secrets.NewSecretValue("s3cr3t")
+
+	assert.Equal(t, "s3cr3t", sv.Reveal())
+	assert.Equal(t, secrets.RedactedMarker, sv.String())
+
+	b, err := json.Marshal(sv)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"***"`, string(b))
+
+	// Inside a map[string]any (how node I/O flows to journal/snapshot/trace).
+	mb, err := json.Marshal(map[string]any{"apiKey": sv, "plain": "x"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"apiKey":"***","plain":"x"}`, string(mb))
+}
+
+func TestSecretRefs(t *testing.T) {
+	t.Parallel()
+	assert.True(t, secrets.HasSecretRef("Bearer {{secret:api-token}}"))
+	assert.False(t, secrets.HasSecretRef("no refs here"))
+	assert.Equal(t, []string{"a", "b"}, secrets.SecretRefNames("{{secret:a}} and {{secret:b}} and {{secret:a}}"))
+
+	out, err := secrets.ReplaceSecretRefs("Bearer {{secret:tok}}!", func(name string) (string, error) {
+		assert.Equal(t, "tok", name)
+		return "XYZ", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer XYZ!", out)
+}
+
+func TestCipher_RoundTrip(t *testing.T) {
+	t.Parallel()
+	key := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	c, err := secrets.NewCipherFromBase64Key(key)
+	require.NoError(t, err)
+
+	ct, err := c.Encrypt([]byte("hunter2"))
+	require.NoError(t, err)
+	assert.NotEqual(t, "hunter2", string(ct), "ciphertext must not equal plaintext")
+
+	pt, err := c.Decrypt(ct)
+	require.NoError(t, err)
+	assert.Equal(t, "hunter2", string(pt))
+
+	// Tampering is detected (GCM auth).
+	ct[len(ct)-1] ^= 0xFF
+	_, err = c.Decrypt(ct)
+	assert.Error(t, err)
+}
+
+func TestCipher_BadKey(t *testing.T) {
+	t.Parallel()
+	_, err := secrets.NewCipherFromBase64Key("not-base64!!")
+	assert.Error(t, err)
+	_, err = secrets.NewCipherFromBase64Key(base64.StdEncoding.EncodeToString(make([]byte, 16)))
+	assert.Error(t, err, "key must be 32 bytes")
+}
+
+func TestMemorySecretStore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := secrets.NewMemorySecretStore()
+	scope := secrets.Scope{Environment: "prod"}
+
+	_, err := s.Resolve(ctx, scope, "missing")
+	require.ErrorIs(t, err, secrets.ErrSecretNotFound)
+
+	require.NoError(t, s.Set(ctx, scope, "api-key", "abc"))
+	v, err := s.Resolve(ctx, scope, "api-key")
+	require.NoError(t, err)
+	assert.Equal(t, "abc", v.Reveal())
+
+	// Scoped by environment.
+	_, err = s.Resolve(ctx, secrets.Scope{Environment: "dev"}, "api-key")
+	require.ErrorIs(t, err, secrets.ErrSecretNotFound)
+
+	names, err := s.List(ctx, "prod")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"api-key"}, names)
+
+	require.NoError(t, s.Delete(ctx, scope, "api-key"))
+	_, err = s.Resolve(ctx, scope, "api-key")
+	require.ErrorIs(t, err, secrets.ErrSecretNotFound)
+}
+
+func TestMemorySecretStoreFromEnv(t *testing.T) {
+	t.Setenv("FUSE_SECRET_GREETING", "hello")
+	s := secrets.NewMemorySecretStoreFromEnv("default")
+	v, err := s.Resolve(context.Background(), secrets.Scope{Environment: "default"}, "GREETING")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", v.Reveal())
+}
+
+func TestResolver_BindsEnvironment(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := secrets.NewMemorySecretStore()
+	require.NoError(t, store.Set(ctx, secrets.Scope{Environment: "staging"}, "tok", "T"))
+
+	r := secrets.NewResolver(store, "staging")
+	v, err := r.Resolve(ctx, "wf-1", "tok")
+	require.NoError(t, err)
+	assert.Equal(t, "T", v.Reveal())
+}

--- a/pkg/secrets/store.go
+++ b/pkg/secrets/store.go
@@ -1,0 +1,54 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// ErrSecretNotFound is returned when a secret cannot be resolved.
+var ErrSecretNotFound = errors.New("secret not found")
+
+// Scope identifies the resolution context for a secret. Environment is the
+// primary scoping dimension; WorkflowID is available for future per-workflow
+// overrides (backends may ignore it).
+type Scope struct {
+	Environment string
+	WorkflowID  string
+}
+
+// SecretStore resolves secrets by name within a scope (read-only).
+type SecretStore interface {
+	Resolve(ctx context.Context, scope Scope, name string) (SecretValue, error)
+}
+
+// ManagedSecretStore additionally supports administration. The memory and
+// encrypted-Postgres backends implement it; read-only backends (e.g. an external
+// manager) implement only SecretStore.
+type ManagedSecretStore interface {
+	SecretStore
+	Set(ctx context.Context, scope Scope, name, value string) error
+	List(ctx context.Context, environment string) ([]string, error)
+	Delete(ctx context.Context, scope Scope, name string) error
+}
+
+// Resolver is the narrow capability the workflow engine depends on: resolve a
+// secret by name for the running workflow. The environment is bound in, so the
+// engine never deals with scoping or the store directly.
+type Resolver interface {
+	Resolve(ctx context.Context, workflowID, name string) (SecretValue, error)
+}
+
+// NewResolver binds a SecretStore + environment into a Resolver.
+func NewResolver(store SecretStore, environment string) Resolver {
+	return &scopedResolver{store: store, environment: environment}
+}
+
+type scopedResolver struct {
+	store       SecretStore
+	environment string
+}
+
+func (r *scopedResolver) Resolve(ctx context.Context, workflowID, name string) (SecretValue, error) {
+	return r.store.Resolve(ctx, Scope{Environment: r.environment, WorkflowID: workflowID}, strings.TrimSpace(name))
+}

--- a/pkg/secrets/value.go
+++ b/pkg/secrets/value.go
@@ -1,0 +1,86 @@
+// Package secrets provides the secret-value wrapper, the SecretStore seam, the
+// {{secret:NAME}} reference syntax, and the in-memory + AES-256-GCM building
+// blocks shared by the workflow engine and the secret backends.
+//
+// A resolved secret is carried as a SecretValue so it renders as a redaction
+// marker everywhere the engine serializes or logs node input/output, while the
+// consuming function can Reveal() the plaintext where it is actually used.
+package secrets
+
+import (
+	"encoding/json"
+	"regexp"
+)
+
+// RedactedMarker is what a SecretValue renders as in any non-Reveal context.
+const RedactedMarker = "***"
+
+// SecretValue wraps a resolved secret's plaintext. It marshals and stringifies
+// to RedactedMarker so it never leaks into journals, snapshots, traces, logs, or
+// aggregated output; the consuming function calls Reveal() to obtain the
+// plaintext only where the value is actually used.
+type SecretValue struct {
+	plaintext string
+}
+
+// NewSecretValue wraps a plaintext secret.
+func NewSecretValue(plaintext string) SecretValue {
+	return SecretValue{plaintext: plaintext}
+}
+
+// Reveal returns the plaintext. Call this ONLY where the value is consumed (e.g.
+// an HTTP Authorization header), never where it would be logged or persisted.
+func (s SecretValue) Reveal() string { return s.plaintext }
+
+// String renders the redaction marker so fmt/%v never prints the plaintext.
+func (s SecretValue) String() string { return RedactedMarker }
+
+// MarshalJSON renders the redaction marker so every JSON sink redacts the value.
+func (s SecretValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(RedactedMarker)
+}
+
+// secretRefPattern matches {{secret:NAME}} tokens; NAME is [A-Za-z0-9_.-]+.
+var secretRefPattern = regexp.MustCompile(`\{\{secret:([A-Za-z0-9_.\-]+)\}\}`)
+
+// HasSecretRef reports whether s contains any {{secret:NAME}} token.
+func HasSecretRef(s string) bool {
+	return secretRefPattern.MatchString(s)
+}
+
+// SecretRefNames returns the distinct secret names referenced in s.
+func SecretRefNames(s string) []string {
+	matches := secretRefPattern.FindAllStringSubmatch(s, -1)
+	names := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		if _, ok := seen[m[1]]; ok {
+			continue
+		}
+		seen[m[1]] = struct{}{}
+		names = append(names, m[1])
+	}
+	return names
+}
+
+// ReplaceSecretRefs replaces each {{secret:NAME}} in s with resolve(NAME),
+// returning the first resolution error if any.
+func ReplaceSecretRefs(s string, resolve func(name string) (string, error)) (string, error) {
+	var firstErr error
+	out := secretRefPattern.ReplaceAllStringFunc(s, func(token string) string {
+		if firstErr != nil {
+			return token
+		}
+		m := secretRefPattern.FindStringSubmatch(token)
+		val, err := resolve(m[1])
+		if err != nil {
+			firstErr = err
+			return token
+		}
+		return val
+	})
+	if firstErr != nil {
+		return "", firstErr
+	}
+	return out, nil
+}

--- a/pkg/workflow/fn_input.go
+++ b/pkg/workflow/fn_input.go
@@ -2,6 +2,7 @@
 package workflow
 
 import (
+	"github.com/open-source-cloud/fuse/pkg/secrets"
 	"github.com/open-source-cloud/fuse/pkg/store"
 )
 
@@ -26,8 +27,14 @@ func (i *FunctionInput) Get(key string) any {
 	return i.store.Get(key)
 }
 
-// GetStr returns the value for the given key as a string
+// GetStr returns the value for the given key as a string. A resolved secret
+// (secrets.SecretValue) is unwrapped to its plaintext here — the one place the
+// consuming function obtains the real value; everywhere else it renders as the
+// redaction marker.
 func (i *FunctionInput) GetStr(key string) string {
+	if sv, ok := i.store.Get(key).(secrets.SecretValue); ok {
+		return sv.Reveal()
+	}
 	return i.store.GetStr(key)
 }
 

--- a/pkg/workflow/fn_input_secret_test.go
+++ b/pkg/workflow/fn_input_secret_test.go
@@ -1,0 +1,32 @@
+package workflow_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunctionInput_SecretRedaction(t *testing.T) {
+	t.Parallel()
+	in, err := workflow.NewFunctionInputWith(map[string]any{
+		"apiKey": secrets.NewSecretValue("s3cr3t"),
+		"plain":  "visible",
+	})
+	require.NoError(t, err)
+
+	// The consuming function obtains the plaintext via GetStr.
+	assert.Equal(t, "s3cr3t", in.GetStr("apiKey"))
+	assert.Equal(t, "visible", in.GetStr("plain"))
+
+	// But anywhere the input map is serialized (journal / snapshot / trace / logs)
+	// the secret is redacted.
+	b, err := json.Marshal(in.Raw())
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"***"`)
+	assert.NotContains(t, string(b), "s3cr3t")
+	assert.Contains(t, string(b), "visible")
+}

--- a/tests/functional/secret_store_test.go
+++ b/tests/functional/secret_store_test.go
@@ -1,0 +1,60 @@
+//go:build functional
+
+package functional_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/internal/repositories/postgres"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresSecretStore_EncryptedRoundTrip(t *testing.T) {
+	pool := setupTestPool(t)
+	ctx := context.Background()
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE secrets")
+
+	key := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	cipher, err := secrets.NewCipherFromBase64Key(key)
+	require.NoError(t, err)
+
+	store := postgres.NewSecretStore(pool, cipher)
+	scope := secrets.Scope{Environment: "prod"}
+
+	// Not found initially.
+	_, err = store.Resolve(ctx, scope, "api-key")
+	require.ErrorIs(t, err, secrets.ErrSecretNotFound)
+
+	// Set + resolve (decrypts back to plaintext).
+	require.NoError(t, store.Set(ctx, scope, "api-key", "s3cr3t"))
+	v, err := store.Resolve(ctx, scope, "api-key")
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t", v.Reveal())
+
+	// The stored column is ciphertext, never plaintext.
+	var enc []byte
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT encrypted_value FROM secrets WHERE environment=$1 AND name=$2", "prod", "api-key").Scan(&enc))
+	assert.NotContains(t, string(enc), "s3cr3t", "secret must be encrypted at rest")
+
+	// Upsert replaces (rotation).
+	require.NoError(t, store.Set(ctx, scope, "api-key", "rotated"))
+	v, err = store.Resolve(ctx, scope, "api-key")
+	require.NoError(t, err)
+	assert.Equal(t, "rotated", v.Reveal())
+
+	// List is scoped to the environment.
+	require.NoError(t, store.Set(ctx, secrets.Scope{Environment: "dev"}, "other", "x"))
+	names, err := store.List(ctx, "prod")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"api-key"}, names)
+
+	// Delete.
+	require.NoError(t, store.Delete(ctx, scope, "api-key"))
+	_, err = store.Resolve(ctx, scope, "api-key")
+	require.ErrorIs(t, err, secrets.ErrSecretNotFound)
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 of [ADR-0031](docs/adr/0031-settings-secrets-and-environments.md)**: workflows can reference secrets by name, the engine resolves them per environment **at input‑mapping time**, and resolved values are **redacted from every sink**. Two backends ship now — **memory** and **encrypted‑Postgres** — with a `fuse secrets` admin CLI. (Infisical is a fast‑follow PR.)

### How a secret reaches a node (the design)
The schema holds only a *reference*; nothing secret is inlined. Two forms, both supported:
- `{{secret:NAME}}` embedded in any `source:"schema"` string (e.g. `"Bearer {{secret:tok}}"`)
- explicit `{"source":"secret","variable":"NAME","mapTo":"apiKey"}`

`Workflow.inputMapping()` resolves the reference via an injected `secrets.Resolver` (scoped by `{environment, workflowID}`), wraps the result in a `SecretValue`, and sets it as the node input. The `Resolver` is threaded through `WorkflowHandler` (new + replay paths).

### Redaction (automatic)
`SecretValue.MarshalJSON()`/`String()` return `***`, so every engine sink that serializes node I/O — journal, execution snapshot, traces, `aggregatedOutput`, actor debug logs — redacts automatically. `FunctionInput.GetStr` is the **one** place the plaintext is unwrapped (for the consuming function). Proven end‑to‑end: a `{{secret:NAME}}` mapped into a node resolves for the function, but the snapshot shows `***`, never the plaintext.

### Backends (selected by `SECRETS_DRIVER`, mirroring `OBJECT_STORE_DRIVER`)
- **memory** — dev; seedable from `FUSE_SECRET_<NAME>` env vars.
- **postgres** — **AES‑256‑GCM** encrypted at rest (`SECRETS_ENCRYPTION_KEY`, base64 32‑byte); new `secrets` table (migration `000008`). The column only ever holds ciphertext.

### Admin CLI
`fuse secrets set/list/delete [--env]` — encrypts on write; requires a managed backend.

### Config
`SecretsConfig` (`SECRETS_DRIVER`, `SECRETS_ENCRYPTION_KEY`) + `FUSE_ENVIRONMENT`.

## Verification
- `make lint` **0 issues** · `make build` OK · `make test` **633**.
- `pkg/secrets` unit tests (redaction, AES round‑trip + tamper detection, memory store, resolver); engine resolution + `GetStr` redaction tests.
- PG encrypted round‑trip under `make test-functional` (asserts the stored column is ciphertext).
- End‑to‑end: `FUSE_SECRET_GREETING=… fuse workflow -c <demo>` → function receives plaintext, snapshot shows `***` (plaintext absent).

## Scope / deferred
- **Infisical** read‑only backend → fast‑follow PR.
- Credential objects (ADR‑0031 Phase 2) and per‑context **LLM provider keys** from secrets (Phase 3 — needs decoupling provider construction from startup DI) remain scheduled. The general mechanism here already lets any node input reference a secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
