### PR TITLE
ci: fix flaky/broken CI (swagger build for ai-e2e + ECR postgres mirror for functional)

### DIFF
--- a/.github/workflows/ai-e2e.yml
+++ b/.github/workflows/ai-e2e.yml
@@ -47,6 +47,16 @@ jobs:
             **/go.sum
             **/go.mod
 
+      # internal/actors/mux_server.go imports the generated `docs` package (gitignored),
+      # so swagger must be generated before building (same as the CI build job).
+      - name: Install swag
+        run: |
+          go install github.com/swaggo/swag/v2/cmd/swag@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Generate swagger docs
+        run: make swagger
+
       - name: Build fuse
         run: make build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:17
+        # AWS ECR public mirror of the official postgres image — byte-identical, but not subject to
+        # Docker Hub's unauthenticated pull rate limits / timeouts that flake the service-container
+        # startup ("registry-1.docker.io: context deadline exceeded") on shared GitHub runner IPs.
+        image: public.ecr.aws/docker/library/postgres:17
         env:
           POSTGRES_USER: fuse
           POSTGRES_PASSWORD: fuse


### PR DESCRIPTION
## Why

Two independent CI reliability problems were turning PRs red.

### 1. `ai-e2e` build failure (original fix)
`internal/actors/mux_server.go` imports the **generated** `github.com/open-source-cloud/fuse/docs`
Swagger package, which is gitignored and produced by `make swagger`. The `ai-e2e` workflow ran
`make build` without generating it first, so it failed with:

```
internal/actors/mux_server.go:17:2: no required module provides package github.com/open-source-cloud/fuse/docs
```

Fix: install `swag` and run `make swagger` before `make build` in `ai-e2e.yml` (matching the CI `build` job).

### 2. `functional` job Docker Hub flake (this commit)
The `functional` job's `postgres:17` **service container** intermittently failed to start because
Docker Hub timed out the unauthenticated pull on shared GitHub-runner IPs:

```
docker pull postgres:17 → Get "https://registry-1.docker.io/v2/": context deadline exceeded  (x3 retries)
```

Fix: pull the **byte-identical** official image from the AWS ECR public mirror
(`public.ecr.aws/docker/library/postgres:17`), which has no Docker Hub rate limits. Removes a
recurring flake for every PR, not just this one.

## Verification
- The CI `build` job (same swagger + build + lint + test path) is green, confirming fix #1.
- Reproduced fix #1 locally: `rm docs/*` → `make build` fails → `make swagger && make build` passes.
- Fix #2 swaps only the registry the official Postgres image is pulled from; env, ports, and health-check are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)