### PR TITLE
feat(secrets): per-execution environment scoping for secret resolution (ADR-0031 Phase 3, PR A)

### DIFF
--- a/internal/actors/workflow_handler.go
+++ b/internal/actors/workflow_handler.go
@@ -44,7 +44,7 @@ func NewWorkflowHandlerFactory(
 	eventBus events.EventBus,
 	fuseMetrics *metrics.FuseMetrics,
 	tracingProvider *tracing.Provider,
-	secretResolver secrets.Resolver,
+	secretStore secrets.SecretStore,
 ) *WorkflowHandlerFactory {
 	return &WorkflowHandlerFactory{
 		Factory: func() gen.ProcessBehavior {
@@ -59,7 +59,7 @@ func NewWorkflowHandlerFactory(
 				eventBus:           eventBus,
 				fuseMetrics:        fuseMetrics,
 				tracingProvider:    tracingProvider,
-				secretResolver:     secretResolver,
+				secretStore:        secretStore,
 			}
 		},
 	}
@@ -80,7 +80,7 @@ type (
 		eventBus           events.EventBus
 		fuseMetrics        *metrics.FuseMetrics
 		tracingProvider    *tracing.Provider
-		secretResolver     secrets.Resolver
+		secretStore        secrets.SecretStore
 
 		workflow       *internalworkflow.Workflow
 		executionTimer *ExecutionTimer
@@ -98,8 +98,9 @@ type (
 
 	// WorkflowHandlerInitArgs defines the typed arguments for the WorkflowHandler Actor Init message
 	WorkflowHandlerInitArgs struct {
-		schemaID   string
-		workflowID workflow.ID
+		schemaID    string
+		workflowID  workflow.ID
+		environment string
 	}
 )
 
@@ -123,7 +124,9 @@ func (a *WorkflowHandler) Init(args ...any) error {
 
 	if a.workflowRepository.Exists(initArgs.workflowID.String()) {
 		a.workflow, _ = a.workflowRepository.Get(initArgs.workflowID.String())
-		a.workflow.SetSecretResolver(a.secretResolver)
+		// Replay: the environment comes from the reconstructed workflow, not init args, so
+		// resolution stays deterministic across restart/recovery (ADR-0031).
+		a.workflow.SetSecretResolver(a.newSecretResolver(a.workflow.Environment()))
 		if err := a.graphService.EnsureNodeMetadata(a.workflow.Graph()); err != nil {
 			a.Log().Error("failed to populate graph node metadata for workflow %s: %s", initArgs.workflowID, err)
 			return gen.TerminateReasonPanic
@@ -155,8 +158,12 @@ func (a *WorkflowHandler) Init(args ...any) error {
 		a.Log().Error("failed to get graph for schema id %s: %s", initArgs.schemaID, err)
 		return gen.TerminateReasonPanic
 	}
-	a.workflow = internalworkflow.New(initArgs.workflowID, graphRef)
-	a.workflow.SetSecretResolver(a.secretResolver)
+	env := initArgs.environment
+	if env == "" {
+		env = a.config.Environment
+	}
+	a.workflow = internalworkflow.New(initArgs.workflowID, graphRef, env)
+	a.workflow.SetSecretResolver(a.newSecretResolver(env))
 	if a.workflowRepository.Save(a.workflow) != nil {
 		a.Log().Error("failed to save workflow for id %s: %s", initArgs.workflowID, err)
 		return nil
@@ -169,6 +176,16 @@ func (a *WorkflowHandler) Init(args ...any) error {
 	a.startWorkflowTimeout()
 	a.handleWorkflowAction(action)
 	return nil
+}
+
+// newSecretResolver builds a secret resolver scoped to the workflow's environment, falling
+// back to the engine default when none was recorded (ADR-0031). Each workflow gets its own
+// resolver so different executions can resolve against different environments.
+func (a *WorkflowHandler) newSecretResolver(environment string) secrets.Resolver {
+	if environment == "" {
+		environment = a.config.Environment
+	}
+	return secrets.NewResolver(a.secretStore, environment)
 }
 
 // startRootSpan begins the OTel root span for this workflow and increments active workflow metrics.
@@ -858,7 +875,8 @@ func (a *WorkflowHandler) handleSubWorkflowAction(action *workflowactions.RunSub
 		},
 	})
 
-	triggerMsg := messaging.NewTriggerWorkflowMessage(action.SchemaID, childWorkflowID)
+	// Sub-workflows inherit the parent's environment so secret resolution stays consistent (ADR-0031).
+	triggerMsg := messaging.NewTriggerWorkflowWithEnvMessage(action.SchemaID, childWorkflowID, a.workflow.Environment())
 	if err := a.Send(gen.Atom(actornames.WorkflowSupervisorName), triggerMsg); err != nil {
 		a.Log().Error("failed to trigger sub-workflow: %s", err)
 		return

--- a/internal/actors/workflow_instance_sup.go
+++ b/internal/actors/workflow_instance_sup.go
@@ -53,21 +53,26 @@ type (
 func (a *WorkflowInstanceSupervisor) Init(args ...any) (act.SupervisorSpec, error) {
 	a.Log().Info("starting process %s with args %s", a.PID(), args)
 
-	if len(args) != 2 {
-		return act.SupervisorSpec{}, fmt.Errorf("workflow instance supervisor init args must be 2 == [workflowID, workflowSchemaID]")
+	if len(args) != 3 {
+		return act.SupervisorSpec{}, fmt.Errorf("workflow instance supervisor init args must be 3 == [workflowID, workflowSchemaID, environment]")
 	}
 	workflowID, ok := args[0].(workflow.ID)
 	if !ok {
-		return act.SupervisorSpec{}, fmt.Errorf("workflow instance supervisor init args must be 2 == [workflowID, workflowSchemaID]; first arg must be a workflow.ID, got %T", args[0])
+		return act.SupervisorSpec{}, fmt.Errorf("workflow instance supervisor init args must be 3 == [workflowID, workflowSchemaID, environment]; first arg must be a workflow.ID, got %T", args[0])
 	}
 	schemaID, ok := args[1].(string)
 	if !ok {
-		return act.SupervisorSpec{}, fmt.Errorf("workflow instance supervisor init args must be 2 == [workflowID, workflowSchemaID]; second arg must be a string, got %T", args[1])
+		return act.SupervisorSpec{}, fmt.Errorf("workflow instance supervisor init args must be 3 == [workflowID, workflowSchemaID, environment]; second arg must be a string, got %T", args[1])
+	}
+	environment, ok := args[2].(string)
+	if !ok {
+		return act.SupervisorSpec{}, fmt.Errorf("workflow instance supervisor init args must be 3 == [workflowID, workflowSchemaID, environment]; third arg must be a string, got %T", args[2])
 	}
 
 	handlerInitArgs := WorkflowHandlerInitArgs{
-		schemaID:   schemaID,
-		workflowID: workflowID,
+		schemaID:    schemaID,
+		workflowID:  workflowID,
+		environment: environment,
 	}
 
 	// supervisor specification

--- a/internal/actors/workflow_sup.go
+++ b/internal/actors/workflow_sup.go
@@ -115,7 +115,7 @@ func (a *WorkflowSupervisor) HandleMessage(from gen.PID, message any) error {
 			a.releaseMap[triggerMsg.WorkflowID] = release
 		}
 
-		err = a.spawnWorkflowActor(triggerMsg.SchemaID, triggerMsg.WorkflowID)
+		err = a.spawnWorkflowActor(triggerMsg.SchemaID, triggerMsg.WorkflowID, triggerMsg.Environment)
 		if err != nil {
 			a.Log().Error("failed to spawn workflow actor for schema id %s : %s", triggerMsg.SchemaID, err)
 			// Release concurrency slot on spawn failure
@@ -153,7 +153,7 @@ func (a *WorkflowSupervisor) HandleMessage(from gen.PID, message any) error {
 				a.Log().Error("failed to get workflow %s for retry: %s", retryMsg.WorkflowID, getErr)
 				return nil
 			}
-			if spawnErr := a.spawnWorkflowActor(wf.Graph().ID(), retryMsg.WorkflowID); spawnErr != nil {
+			if spawnErr := a.spawnWorkflowActor(wf.Graph().ID(), retryMsg.WorkflowID, wf.Environment()); spawnErr != nil {
 				a.Log().Error("failed to respawn workflow %s for retry: %s", retryMsg.WorkflowID, spawnErr)
 				return nil
 			}
@@ -228,14 +228,14 @@ func (a *WorkflowSupervisor) recoverWorkflows() {
 			continue
 		}
 		schemaID := wf.Schema().ID
-		if spawnErr := a.spawnWorkflowActor(schemaID, wf.ID()); spawnErr != nil {
+		if spawnErr := a.spawnWorkflowActor(schemaID, wf.ID(), wf.Environment()); spawnErr != nil {
 			a.Log().Error("failed to recover workflow %s: %s", id, spawnErr)
 		}
 	}
 }
 
-func (a *WorkflowSupervisor) spawnWorkflowActor(schemaID string, workflowID workflow.ID) error {
-	err := a.StartChild(actornames.WorkflowInstanceSupervisor, workflowID, schemaID)
+func (a *WorkflowSupervisor) spawnWorkflowActor(schemaID string, workflowID workflow.ID, environment string) error {
+	err := a.StartChild(actornames.WorkflowInstanceSupervisor, workflowID, schemaID, environment)
 	if err != nil {
 		a.Log().Error("failed to spawn child for schema id %s : %s", schemaID, err)
 		return err

--- a/internal/app/cli/workflow.go
+++ b/internal/app/cli/workflow.go
@@ -25,6 +25,10 @@ import (
 // workflowSpecFile is the path to the workflow spec file (-c/--config).
 var workflowSpecFile string
 
+// workflowEnvironment scopes secret resolution for the run (-e/--environment); empty uses the
+// engine default (FUSE_ENVIRONMENT).
+var workflowEnvironment string
+
 const (
 	workflowRunHealthAttempts = 60
 	workflowRunPollInterval   = 250 * time.Millisecond
@@ -43,6 +47,7 @@ func newWorkflowCommand() *cobra.Command {
 		RunE: func(*cobra.Command, []string) error { return runWorkflowApp() },
 	}
 	workflowCmd.Flags().StringVarP(&workflowSpecFile, "config", "c", "", "Path to the workflow spec JSON file")
+	workflowCmd.Flags().StringVarP(&workflowEnvironment, "environment", "e", "", "Environment scope for secret resolution (defaults to FUSE_ENVIRONMENT)")
 	return workflowCmd
 }
 
@@ -110,7 +115,7 @@ func runWorkflowOnce(cfg *config.Config, gs services.GraphService, spec []byte) 
 		return fmt.Errorf("upsert workflow graph: %w", err)
 	}
 
-	wfID, err := workflowTrigger(client, base, graph.ID())
+	wfID, err := workflowTrigger(client, base, graph.ID(), workflowEnvironment)
 	if err != nil {
 		return err
 	}
@@ -144,8 +149,12 @@ func workflowWaitHealth(client *http.Client, base string) error {
 	return errors.New("workflow runner: in-process server did not become healthy")
 }
 
-func workflowTrigger(client *http.Client, base, schemaID string) (string, error) {
-	payload, _ := json.Marshal(map[string]string{"schemaID": schemaID})
+func workflowTrigger(client *http.Client, base, schemaID, environment string) (string, error) {
+	reqBody := map[string]string{"schemaID": schemaID}
+	if environment != "" {
+		reqBody["environment"] = environment
+	}
+	payload, _ := json.Marshal(reqBody)
 	resp, err := client.Post(base+"/v1/workflows/trigger", "application/json", bytes.NewReader(payload)) //nolint:noctx // short-lived CLI call
 	if err != nil {
 		return "", fmt.Errorf("trigger workflow: %w", err)

--- a/internal/app/di/secrets.go
+++ b/internal/app/di/secrets.go
@@ -11,13 +11,13 @@ import (
 	"go.uber.org/fx"
 )
 
-// SecretsModule provides the SecretStore (selected by SECRETS_DRIVER) and the
-// narrow Resolver the workflow engine uses to resolve secret references.
+// SecretsModule provides the SecretStore (selected by SECRETS_DRIVER). The workflow engine
+// builds a per-workflow, environment-scoped Resolver from this store at execution time
+// (ADR-0031), so no process-wide Resolver is provided here.
 var SecretsModule = fx.Module(
 	"secrets",
 	fx.Provide(
 		provideSecretStore,
-		provideSecretResolver,
 	),
 )
 
@@ -47,9 +47,4 @@ func provideSecretStore(p secretStoreParams) (secrets.SecretStore, error) {
 		log.Debug().Str("environment", p.Config.Environment).Msg("using memory secret store")
 		return secrets.NewMemorySecretStoreFromEnv(p.Config.Environment), nil
 	}
-}
-
-// provideSecretResolver binds the store + configured environment into a Resolver.
-func provideSecretResolver(store secrets.SecretStore, cfg *config.Config) secrets.Resolver {
-	return secrets.NewResolver(store, cfg.Environment)
 }

--- a/internal/dtos/workflow.go
+++ b/internal/dtos/workflow.go
@@ -11,6 +11,9 @@ type UpsertSchemaResponse struct {
 type TriggerWorkflowRequest struct {
 	SchemaID       string `json:"schemaID" validate:"required"`
 	IdempotencyKey string `json:"idempotencyKey,omitempty"`
+	// Environment scopes secret resolution for this execution (ADR-0031). Empty defaults to
+	// the engine's configured environment (FUSE_ENVIRONMENT).
+	Environment string `json:"environment,omitempty" example:"staging"`
 }
 
 // TriggerWorkflowResponse represents trigger workflow response
@@ -19,6 +22,7 @@ type TriggerWorkflowResponse struct {
 	WorkflowID   string `json:"workflowId" example:"550e8400-e29b-41d4-a716-446655440000"`
 	Code         string `json:"code" example:"OK"`
 	Deduplicated bool   `json:"deduplicated,omitempty" example:"false"`
+	Environment  string `json:"environment,omitempty" example:"staging"`
 }
 
 // AsyncFunctionRequest is the request body for the AsyncFunctionHandler

--- a/internal/handlers/trigger_workflow.go
+++ b/internal/handlers/trigger_workflow.go
@@ -18,8 +18,9 @@ type (
 	// TriggerWorkflowHandler is the handler for the TriggerWorkflow endpoint
 	TriggerWorkflowHandler struct {
 		Handler
-		idempotencyStore idempotency.Store
-		idempotencyTTL   config.IdempotencyConfig
+		idempotencyStore   idempotency.Store
+		idempotencyTTL     config.IdempotencyConfig
+		defaultEnvironment string
 	}
 	// TriggerWorkflowHandlerFactory is a factory for creating TriggerWorkflowHandler actors
 	TriggerWorkflowHandlerFactory HandlerFactory[*TriggerWorkflowHandler]
@@ -39,8 +40,9 @@ func NewTriggerWorkflowHandlerFactory(store idempotency.Store, cfg *config.Confi
 	return &TriggerWorkflowHandlerFactory{
 		Factory: func() gen.ProcessBehavior {
 			return &TriggerWorkflowHandler{
-				idempotencyStore: store,
-				idempotencyTTL:   cfg.Idempotency,
+				idempotencyStore:   store,
+				idempotencyTTL:     cfg.Idempotency,
+				defaultEnvironment: cfg.Environment,
 			}
 		},
 	}
@@ -81,8 +83,13 @@ func (h *TriggerWorkflowHandler) HandlePost(from gen.PID, w http.ResponseWriter,
 		}
 	}
 
+	environment := req.Environment
+	if environment == "" {
+		environment = h.defaultEnvironment
+	}
+
 	workflowID := workflow.NewID()
-	if err := h.Send(WorkflowSupervisorName, messaging.NewTriggerWorkflowMessage(req.SchemaID, workflowID)); err != nil {
+	if err := h.Send(WorkflowSupervisorName, messaging.NewTriggerWorkflowWithEnvMessage(req.SchemaID, workflowID, environment)); err != nil {
 		return h.SendInternalError(w, err)
 	}
 
@@ -94,8 +101,9 @@ func (h *TriggerWorkflowHandler) HandlePost(from gen.PID, w http.ResponseWriter,
 	}
 
 	return h.SendJSON(w, http.StatusOK, dtos.TriggerWorkflowResponse{
-		SchemaID:   req.SchemaID,
-		WorkflowID: workflowID.String(),
-		Code:       "OK",
+		SchemaID:    req.SchemaID,
+		WorkflowID:  workflowID.String(),
+		Code:        "OK",
+		Environment: environment,
 	})
 }

--- a/internal/messaging/trigger_workflow.go
+++ b/internal/messaging/trigger_workflow.go
@@ -10,6 +10,9 @@ type TriggerWorkflowMessage struct {
 	SchemaID   string
 	WorkflowID workflow.ID
 	Input      map[string]any
+	// Environment scopes secret resolution for this execution (ADR-0031). Empty means the
+	// engine default applies (resolved by the WorkflowHandler).
+	Environment string
 }
 
 // NewTriggerWorkflowMessage creates a new TriggerWorkflow message
@@ -19,6 +22,18 @@ func NewTriggerWorkflowMessage(schemaID string, workflowID workflow.ID) Message 
 		Args: TriggerWorkflowMessage{
 			SchemaID:   schemaID,
 			WorkflowID: workflowID,
+		},
+	}
+}
+
+// NewTriggerWorkflowWithEnvMessage creates a TriggerWorkflow message scoped to an environment.
+func NewTriggerWorkflowWithEnvMessage(schemaID string, workflowID workflow.ID, environment string) Message {
+	return Message{
+		Type: TriggerWorkflow,
+		Args: TriggerWorkflowMessage{
+			SchemaID:    schemaID,
+			WorkflowID:  workflowID,
+			Environment: environment,
 		},
 	}
 }

--- a/internal/repositories/postgres/migrations/000009_add_workflow_environment.down.sql
+++ b/internal/repositories/postgres/migrations/000009_add_workflow_environment.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_workflows_environment;
+ALTER TABLE workflows DROP COLUMN IF EXISTS environment;

--- a/internal/repositories/postgres/migrations/000009_add_workflow_environment.up.sql
+++ b/internal/repositories/postgres/migrations/000009_add_workflow_environment.up.sql
@@ -1,0 +1,8 @@
+-- ADR-0031 Phase 3: environment becomes a per-execution scoping dimension.
+-- The environment chosen at trigger time is persisted here so actor restart / journal
+-- replay resolves secrets against the same environment. NOT NULL DEFAULT 'default'
+-- backfills in-flight workflows created before this migration.
+
+ALTER TABLE workflows ADD COLUMN environment VARCHAR(128) NOT NULL DEFAULT 'default';
+
+CREATE INDEX idx_workflows_environment ON workflows (environment);

--- a/internal/repositories/postgres/workflow.go
+++ b/internal/repositories/postgres/workflow.go
@@ -45,12 +45,12 @@ func (r *WorkflowRepository) Exists(id string) bool {
 func (r *WorkflowRepository) Get(id string) (*workflow.Workflow, error) {
 	ctx := context.Background()
 
-	var schemaID, state string
+	var schemaID, state, environment string
 	var outputRef *string
 	err := r.pool.QueryRow(ctx, `
-		SELECT schema_id, state, output_ref
+		SELECT schema_id, state, output_ref, environment
 		FROM workflows WHERE workflow_id = $1
-	`, id).Scan(&schemaID, &state, &outputRef)
+	`, id).Scan(&schemaID, &state, &outputRef, &environment)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, fmt.Errorf("workflow %s not found", id)
@@ -64,7 +64,7 @@ func (r *WorkflowRepository) Get(id string) (*workflow.Workflow, error) {
 		return nil, fmt.Errorf("postgres/workflow: load graph for %q: %w", schemaID, err)
 	}
 
-	wf := workflow.New(pkgwf.ID(id), graph)
+	wf := workflow.New(pkgwf.ID(id), graph, environment)
 
 	// Restore state without appending a journal entry.
 	// SetState() appends a state:changed journal entry, which is wrong during reconstruction.
@@ -96,14 +96,16 @@ func (r *WorkflowRepository) Save(wf *workflow.Workflow) error {
 		outputRef = &key
 	}
 
+	// environment is set once at create and intentionally excluded from the DO UPDATE clause:
+	// later saves happen on every state change and must not clobber the original scope (ADR-0031).
 	_, err := r.pool.Exec(ctx, `
-		INSERT INTO workflows (workflow_id, schema_id, state, output_ref, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, NOW(), NOW())
+		INSERT INTO workflows (workflow_id, schema_id, state, output_ref, environment, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
 		ON CONFLICT (workflow_id) DO UPDATE SET
 			state = EXCLUDED.state,
 			output_ref = EXCLUDED.output_ref,
 			updated_at = NOW()
-	`, wfID, wf.Schema().ID, wf.State().String(), outputRef)
+	`, wfID, wf.Schema().ID, wf.State().String(), outputRef, wf.Environment())
 	if err != nil {
 		return fmt.Errorf("postgres/workflow: save: %w", err)
 	}

--- a/internal/repositories/workflow_memory_test.go
+++ b/internal/repositories/workflow_memory_test.go
@@ -16,7 +16,7 @@ func newTestWorkflow(t *testing.T) *internalworkflow.Workflow {
 	schema := mocks.SmallTestGraphSchema()
 	graph, err := internalworkflow.NewGraph(schema)
 	require.NoError(t, err)
-	return internalworkflow.New(workflow.NewID(), graph)
+	return internalworkflow.New(workflow.NewID(), graph, "default")
 }
 
 func TestMemoryWorkflowRepository_FindByState(t *testing.T) {

--- a/internal/workflow/foreach_test.go
+++ b/internal/workflow/foreach_test.go
@@ -74,7 +74,7 @@ func buildForEachGraph(t *testing.T) *Graph {
 
 func TestStartForEachIteration_ReturnsActionForBodyNode(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	input := map[string]any{"item": "hello", "index": 0, "total": 1, "isLast": true}
 	action, threadID, err := wf.StartForEachIteration("foreach1", input)
@@ -88,7 +88,7 @@ func TestStartForEachIteration_ReturnsActionForBodyNode(t *testing.T) {
 
 func TestStartForEachIteration_AllocatesUniqueThreads(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	_, threadID1, err := wf.StartForEachIteration("foreach1", map[string]any{"index": 0})
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestStartForEachIteration_AllocatesUniqueThreads(t *testing.T) {
 
 func TestStartForEachIteration_WritesJournalEntries(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	_, threadID, err := wf.StartForEachIteration("foreach1", map[string]any{"item": "x"})
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestStartForEachIteration_WritesJournalEntries(t *testing.T) {
 
 func TestStartForEachIteration_ErrorOnMissingNode(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	_, _, err := wf.StartForEachIteration("does-not-exist", nil)
 	assert.Error(t, err)
@@ -159,7 +159,7 @@ func TestStartForEachIteration_ErrorOnMissingEachEdge(t *testing.T) {
 	g, err := NewGraph(schema)
 	require.NoError(t, err)
 
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 	_, _, err = wf.StartForEachIteration("foreach1", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "each")
@@ -169,7 +169,7 @@ func TestStartForEachIteration_ErrorOnMissingEachEdge(t *testing.T) {
 
 func TestCompleteForEach_SetsResultAndPhase(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	// Simulate trigger then foreach node being executed so there's an audit log entry.
 	triggerExecID := workflow.NewExecID(0)
@@ -195,7 +195,7 @@ func TestCompleteForEach_SetsResultAndPhase(t *testing.T) {
 
 func TestLastResultForThread_ReturnsOutputData(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	execID := workflow.NewExecID(5)
 	wf.threads.New(5, execID)
@@ -212,13 +212,13 @@ func TestLastResultForThread_ReturnsOutputData(t *testing.T) {
 
 func TestLastResultForThread_UnknownThread_ReturnsNil(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 	assert.Nil(t, wf.LastResultForThread(99))
 }
 
 func TestLastResultForThread_NoResult_ReturnsNil(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	execID := workflow.NewExecID(7)
 	wf.threads.New(7, execID)
@@ -253,7 +253,7 @@ func TestFindNamedOutputEdge_NotFound(t *testing.T) {
 
 func TestForEach_FullCycleRoutes_ToDoneEdge(t *testing.T) {
 	g := buildForEachGraph(t)
-	wf := New(workflow.NewID(), g)
+	wf := New(workflow.NewID(), g, "default")
 
 	// Simulate: trigger completes, then foreach is about to execute.
 	triggerExecID := workflow.NewExecID(0)

--- a/internal/workflow/handle_node_failure_test.go
+++ b/internal/workflow/handle_node_failure_test.go
@@ -22,7 +22,7 @@ func TestHandleNodeFailure_RoutesOnErrorEdgeWhenRetriesExhausted(t *testing.T) {
 	g, err := NewGraph(schema)
 	require.NoError(t, err)
 
-	w := New(pkgwf.ID("wf-error-edge"), g)
+	w := New(pkgwf.ID("wf-error-edge"), g, "default")
 
 	failNode, err := g.FindNode("fail-node")
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestHandleNodeFailure_RetriesWhenPolicyAllows(t *testing.T) {
 	g, err := NewGraph(schema)
 	require.NoError(t, err)
 
-	w := New(pkgwf.ID("wf-parallel-retry"), g)
+	w := New(pkgwf.ID("wf-parallel-retry"), g, "default")
 
 	branchB, err := g.FindNode("branch-b")
 	require.NoError(t, err)

--- a/internal/workflow/retry_node_test.go
+++ b/internal/workflow/retry_node_test.go
@@ -25,7 +25,7 @@ func loadTestGraph(t *testing.T) *Graph {
 func setupFailedWorkflow(t *testing.T) (*Workflow, workflow.ExecID) {
 	t.Helper()
 	graph := loadTestGraph(t)
-	wf := New(workflow.NewID(), graph)
+	wf := New(workflow.NewID(), graph, "default")
 
 	// Trigger the workflow
 	action := wf.Trigger()
@@ -79,7 +79,7 @@ func TestRetryNode_HappyPath(t *testing.T) {
 func TestRetryNode_WrongState(t *testing.T) {
 	// Arrange
 	graph := loadTestGraph(t)
-	wf := New(workflow.NewID(), graph)
+	wf := New(workflow.NewID(), graph, "default")
 	wf.SetState(StateRunning)
 
 	// Act
@@ -105,7 +105,7 @@ func TestRetryNode_ExecNotFound(t *testing.T) {
 func TestRetryNode_ExecNotFailed(t *testing.T) {
 	// Arrange — create a workflow with a completed (not failed) exec
 	graph := loadTestGraph(t)
-	wf := New(workflow.NewID(), graph)
+	wf := New(workflow.NewID(), graph, "default")
 
 	action := wf.Trigger()
 	execID := action.(*workflowactions.RunFunctionAction).FunctionExecID

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -49,11 +49,15 @@ const (
 	logMsgErrorParsingValue     = "Error parsing value"
 )
 
-// New creates a new Workflow from an already generated ID and a provided WorkflowGraph
-func New(id workflow.ID, graph *Graph) *Workflow {
+// New creates a new Workflow from an already generated ID and a provided WorkflowGraph.
+// environment is the resolution scope (ADR-0031) chosen at trigger time; it is persisted so
+// replay resolves secrets against the same environment. An empty value means the engine
+// default applies (the caller resolves it before building the resolver).
+func New(id workflow.ID, graph *Graph, environment string) *Workflow {
 	return &Workflow{
 		id:               id,
 		graph:            graph,
+		environment:      environment,
 		journal:          NewJournal(),
 		auditLog:         NewAuditLog(),
 		retryTracker:     NewRetryTracker(),
@@ -112,6 +116,7 @@ type (
 	Workflow struct {
 		id               workflow.ID
 		graph            *Graph
+		environment      string
 		journal          *Journal
 		auditLog         *AuditLog
 		retryTracker     *RetryTracker
@@ -503,6 +508,12 @@ func (w *Workflow) hasJournalEntryType(execID string, entryType JournalEntryType
 // ID Workflow ID
 func (w *Workflow) ID() workflow.ID {
 	return w.id
+}
+
+// Environment returns the resolution scope (ADR-0031) chosen at trigger time. It is persisted
+// with the workflow so replay resolves secrets against the same environment.
+func (w *Workflow) Environment() string {
+	return w.environment
 }
 
 // State Workflow state

--- a/internal/workflow/workflow_conditionals_test.go
+++ b/internal/workflow/workflow_conditionals_test.go
@@ -275,7 +275,7 @@ func TestWorkflow_StateCancelled(t *testing.T) {
 	graph, err := NewGraph(schema)
 	require.NoError(t, err)
 
-	wf := New(workflow.NewID(), graph)
+	wf := New(workflow.NewID(), graph, "default")
 
 	wf.SetState(StateRunning)
 	assert.Equal(t, StateRunning, wf.State())

--- a/internal/workflow/workflow_env_test.go
+++ b/internal/workflow/workflow_env_test.go
@@ -1,0 +1,32 @@
+package workflow
+
+import (
+	"testing"
+
+	pkgwf "github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStoresEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		environment string
+		want        string
+	}{
+		{name: "explicit environment", environment: "staging", want: "staging"},
+		{name: "default environment", environment: "default", want: "default"},
+		{name: "empty environment", environment: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := New(pkgwf.ID("wf-env"), nil, tt.environment)
+
+			assert.Equal(t, tt.want, w.Environment())
+		})
+	}
+}

--- a/internal/workflow/workflow_sleep_test.go
+++ b/internal/workflow/workflow_sleep_test.go
@@ -106,7 +106,7 @@ func newMinimalWorkflow(t *testing.T) *Workflow {
 	}
 	graph, err := NewGraph(schema)
 	require.NoError(t, err)
-	return New(workflow.NewID(), graph)
+	return New(workflow.NewID(), graph, "default")
 }
 
 func TestReplayJournalEntries_SleepState(t *testing.T) {

--- a/tests/functional/helpers_test.go
+++ b/tests/functional/helpers_test.go
@@ -14,7 +14,7 @@ func newTestWorkflow(t *testing.T) *internalworkflow.Workflow {
 	schema := mocks.SmallTestGraphSchema()
 	graph, err := internalworkflow.NewGraph(schema)
 	require.NoError(t, err)
-	return internalworkflow.New(workflow.NewID(), graph)
+	return internalworkflow.New(workflow.NewID(), graph, "default")
 }
 
 func newTestWorkflowWithID(t *testing.T, id workflow.ID) *internalworkflow.Workflow {
@@ -22,5 +22,13 @@ func newTestWorkflowWithID(t *testing.T, id workflow.ID) *internalworkflow.Workf
 	schema := mocks.SmallTestGraphSchema()
 	graph, err := internalworkflow.NewGraph(schema)
 	require.NoError(t, err)
-	return internalworkflow.New(id, graph)
+	return internalworkflow.New(id, graph, "default")
+}
+
+func newTestWorkflowWithEnv(t *testing.T, environment string) *internalworkflow.Workflow {
+	t.Helper()
+	schema := mocks.SmallTestGraphSchema()
+	graph, err := internalworkflow.NewGraph(schema)
+	require.NoError(t, err)
+	return internalworkflow.New(workflow.NewID(), graph, environment)
 }

--- a/tests/functional/workflow_repository_test.go
+++ b/tests/functional/workflow_repository_test.go
@@ -39,6 +39,19 @@ func contractTestWorkflowRepository(t *testing.T, newRepo func() repositories.Wo
 		assert.Equal(t, internalworkflow.StateRunning, found.State())
 	})
 
+	t.Run("Save and Get preserves environment for deterministic replay", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		wf := newTestWorkflowWithEnv(t, "staging")
+		wf.SetState(internalworkflow.StateSleeping)
+
+		saveWf(t, repo, wf)
+		found, err := repo.Get(wf.ID().String())
+
+		require.NoError(t, err)
+		assert.Equal(t, "staging", found.Environment())
+	})
+
 	t.Run("Exists returns true for saved workflow", func(t *testing.T) {
 		reset()
 		repo := newRepo()


### PR DESCRIPTION
## What & why

ADR-0031 Phase 3, deliverable 1 of 4 (**PR A — threading core**). Makes `environment` a
**per-execution scoping dimension** instead of a single server-wide config string baked into
the secret resolver at DI time. This unblocks per-context LLM keys, credentials, and external
backends, all of which scope by environment.

## Changes

- **Per-workflow scoped resolver:** `workflow.New` gains an `environment` field + getter; the
  `WorkflowHandler` builds a `secrets.NewResolver(store, env)` per workflow. New executions take
  the environment from the trigger (default `FUSE_ENVIRONMENT`); **replay reads it from the
  reconstructed workflow** so resolution is deterministic across restart/recovery/retry. The
  process-wide resolver DI provider is removed.
- **Threading:** `environment` flows trigger → `TriggerWorkflowMessage` → `workflow_sup` spawn →
  instance supervisor → `WorkflowHandlerInitArgs`. Sub-workflows inherit the parent's
  environment. `TriggerWorkflowRequest`/`Response` gain an optional `environment`; `fuse workflow`
  gains `-e/--environment`.
- **Persistence:** migration `000009` adds `workflows.environment` (`NOT NULL DEFAULT 'default'`
  backfill + index); `postgres` `Get` reads it, `Save` writes it and **excludes it from the
  `ON CONFLICT DO UPDATE`** so state-change saves can't clobber it. Memory backend unchanged.

## Tests

`make lint` clean, `make build` ok, `make test` 638→ passing incl. new `TestNewStoresEnvironment`
and a functional contract subtest asserting Save/Get preserves environment (memory + postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)