### PR TITLE
feat(secrets): first-class environments registry + strict trigger validation (ADR-0031 Phase 3, PR B)

### DIFF
--- a/docs/adr/0031-settings-secrets-and-environments.md
+++ b/docs/adr/0031-settings-secrets-and-environments.md
@@ -118,9 +118,19 @@ drivers with the smallest, most incremental change and gives B and C a stable se
   `pkg/secrets` (`SecretValue` → `***` everywhere; `FunctionInput.GetStr` reveals plaintext), the
   **memory** + **encrypted-Postgres** backends (`pkg/secrets/memory.go`,
   `internal/repositories/postgres/secret.go` + migration `000008_create_secrets`), the
-  `SECRETS_DRIVER` selection (`internal/app/di/secrets.go`), and the `fuse secrets` CLI. Infisical
-  (Phase 1's read-only external backend) is a fast-follow; credential objects (Phase 2) and
-  per-context provider keys (Phase 3) remain scheduled.
+  `SECRETS_DRIVER` selection (`internal/app/di/secrets.go`), and the `fuse secrets` CLI.
+- **Phase 3 — explicit environments model shipped**: `environment` is now a per-execution
+  scoping dimension. It is chosen at trigger time (`environment` on `TriggerWorkflowRequest`,
+  `fuse workflow -e`), threaded through the trigger → supervisor → `WorkflowHandler` chain, and
+  persisted on the `workflows` row (migration `000009`) so journal replay / recovery resolve
+  secrets against the same environment; the engine builds a per-workflow `secrets.Resolver`
+  scoped to it (replacing the process-wide one) and sub-workflows inherit the parent's
+  environment. A first-class environments registry (`Environment` domain, memory +
+  Postgres `EnvironmentRepository` + migration `000010` seeding `default`, `EnvironmentService`,
+  CRUD at `/v1/environments`) makes environments declarable, and triggers naming an unknown
+  environment are rejected (HTTP 400). The remaining Phase 3 work — per-context LLM provider
+  keys (dynamic provider construction) — and credential objects (Phase 2) and Infisical (the
+  read-only external backend) remain scheduled.
 - Supersedes [ADR-0008](0008-settings-environments-and-secrets-management.md) (which recorded the
   problem and deferred the decision).
 - Current state this changes: `internal/app/config/config.go` (env-var secrets),

--- a/internal/actors/mux_worker.go
+++ b/internal/actors/mux_worker.go
@@ -126,6 +126,26 @@ func NewWorkers() *Workers {
 				},
 			},
 			{
+				Name:    handlers.EnvironmentsHandlerName,
+				Pattern: "/v1/environments",
+				Methods: []string{"GET"},
+				Timeout: 10 * time.Second,
+				PoolConfig: WorkerPoolConfig{
+					Name:     handlers.EnvironmentsHandlerPoolName,
+					PoolSize: 3,
+				},
+			},
+			{
+				Name:    handlers.EnvironmentHandlerName,
+				Pattern: "/v1/environments/{name}",
+				Methods: []string{"GET", "PUT", "DELETE"},
+				Timeout: 10 * time.Second,
+				PoolConfig: WorkerPoolConfig{
+					Name:     handlers.EnvironmentHandlerPoolName,
+					PoolSize: 3,
+				},
+			},
+			{
 				Name:    handlers.ListSchemaVersionsHandlerName,
 				Pattern: "/v1/schemas/{schemaID}/versions",
 				Methods: []string{"GET"},

--- a/internal/app/di/actors.go
+++ b/internal/app/di/actors.go
@@ -35,6 +35,8 @@ type workerHandlerRegistrationParams struct {
 	GetSchemaVersionHandlerFactory      *handlers.GetSchemaVersionHandlerFactory
 	ActivateSchemaVersionHandlerFactory *handlers.ActivateSchemaVersionHandlerFactory
 	RollbackSchemaHandlerFactory        *handlers.RollbackSchemaHandlerFactory
+	EnvironmentsHandlerFactory          *handlers.EnvironmentsHandlerFactory
+	EnvironmentHandlerFactory           *handlers.EnvironmentHandlerFactory
 }
 
 // newWorkers builds the HTTP worker registry with all handler factories registered.
@@ -65,6 +67,8 @@ func newWorkers(p workerHandlerRegistrationParams) *actors.Workers {
 	w.AddFactory(handlers.GetSchemaVersionHandlerName, p.GetSchemaVersionHandlerFactory.Factory)
 	w.AddFactory(handlers.ActivateSchemaVersionHandlerName, p.ActivateSchemaVersionHandlerFactory.Factory)
 	w.AddFactory(handlers.RollbackSchemaHandlerName, p.RollbackSchemaHandlerFactory.Factory)
+	w.AddFactory(handlers.EnvironmentsHandlerName, p.EnvironmentsHandlerFactory.Factory)
+	w.AddFactory(handlers.EnvironmentHandlerName, p.EnvironmentHandlerFactory.Factory)
 	return w
 }
 
@@ -95,6 +99,8 @@ var WorkerModule = fx.Module(
 		handlers.NewGetSchemaVersionHandlerFactory,
 		handlers.NewActivateSchemaVersionHandlerFactory,
 		handlers.NewRollbackSchemaHandlerFactory,
+		handlers.NewEnvironmentsHandler,
+		handlers.NewEnvironmentHandler,
 		newWorkers,
 	),
 )

--- a/internal/app/di/repos.go
+++ b/internal/app/di/repos.go
@@ -22,6 +22,7 @@ var RepoModule = fx.Module(
 		provideAwakeableRepository,
 		provideClaimRepository,
 		provideTraceRepository,
+		provideEnvironmentRepository,
 	),
 )
 
@@ -84,6 +85,15 @@ func provideClaimRepository(p repoParams) repositories.ClaimRepository {
 	}
 	log.Debug().Msg("using memory claim repository (no-op)")
 	return repositories.NewMemoryClaimRepository()
+}
+
+func provideEnvironmentRepository(p repoParams) repositories.EnvironmentRepository {
+	if p.Config.Database.Driver == config.DBDriverPostgres && p.Pool != nil {
+		log.Debug().Msg("using postgres environment repository")
+		return postgres.NewEnvironmentRepository(p.Pool)
+	}
+	log.Debug().Msg("using memory environment repository")
+	return repositories.NewMemoryEnvironmentRepository()
 }
 
 func provideTraceRepository(p repoParams) repositories.TraceRepository {

--- a/internal/app/di/services.go
+++ b/internal/app/di/services.go
@@ -28,6 +28,7 @@ var ServicesModule = fx.Module(
 		),
 		services.NewGraphService,
 		services.NewPackageService,
+		services.NewEnvironmentService,
 	),
 	fx.Invoke(bindSchemaReplicationPublisher),
 )

--- a/internal/dtos/environment.go
+++ b/internal/dtos/environment.go
@@ -1,0 +1,30 @@
+package dtos
+
+import "github.com/open-source-cloud/fuse/pkg/workflow"
+
+// EnvironmentDTO represents an environment data transfer object.
+type EnvironmentDTO struct {
+	Name        string `json:"name" example:"staging"`
+	Description string `json:"description,omitempty" example:"Staging environment"`
+}
+
+// EnvironmentListResponse represents a list of environments.
+type EnvironmentListResponse struct {
+	Items []EnvironmentDTO `json:"items"`
+}
+
+// UpsertEnvironmentResponse represents an environment upsert response.
+type UpsertEnvironmentResponse struct {
+	Message     string `json:"message" example:"Environment saved successfully"`
+	Environment string `json:"environment" example:"staging"`
+}
+
+// ToEnvironmentDTO converts a domain environment to its DTO.
+func ToEnvironmentDTO(env *workflow.Environment) EnvironmentDTO {
+	return EnvironmentDTO{Name: env.Name, Description: env.Description}
+}
+
+// FromEnvironmentDTO converts a DTO to a domain environment.
+func FromEnvironmentDTO(dto EnvironmentDTO) *workflow.Environment {
+	return workflow.NewEnvironment(dto.Name, dto.Description)
+}

--- a/internal/handlers/environment.go
+++ b/internal/handlers/environment.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"ergo.services/ergo/gen"
+	"github.com/open-source-cloud/fuse/internal/dtos"
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/internal/services"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+const (
+	// EnvironmentHandlerName is the name of the single-environment handler.
+	EnvironmentHandlerName = "environment_handler"
+	// EnvironmentHandlerPoolName is the name of the single-environment handler pool.
+	EnvironmentHandlerPoolName = "environment_handler_pool"
+)
+
+type (
+	// EnvironmentHandlerFactory is the factory for the single-environment handler.
+	EnvironmentHandlerFactory HandlerFactory[*EnvironmentHandler]
+
+	// EnvironmentHandler handles a single environment resource.
+	EnvironmentHandler struct {
+		Handler
+		environmentService services.EnvironmentService
+	}
+)
+
+// NewEnvironmentHandler creates a new single-environment handler factory.
+func NewEnvironmentHandler(environmentService services.EnvironmentService) *EnvironmentHandlerFactory {
+	return &EnvironmentHandlerFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &EnvironmentHandler{
+				environmentService: environmentService,
+			}
+		},
+	}
+}
+
+// HandleGet retrieves a single environment (GET /v1/environments/{name})
+// @Summary Get environment by name
+// @Description Retrieve a single environment
+// @Tags environments
+// @Accept json
+// @Produce json
+// @Param name path string true "Environment name"
+// @Success 200 {object} dtos.EnvironmentDTO
+// @Failure 404 {object} dtos.NotFoundError
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/environments/{name} [get]
+func (h *EnvironmentHandler) HandleGet(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received get environment request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	name, err := h.GetPathParam(r, "name")
+	if err != nil {
+		return h.SendBadRequest(w, err, []string{"name is required"})
+	}
+
+	env, err := h.environmentService.FindByID(name)
+	if err != nil {
+		if errors.Is(err, repositories.ErrEnvironmentNotFound) {
+			return h.SendNotFound(w, fmt.Sprintf("environment %s not found", name), []string{"name"})
+		}
+		return h.SendInternalError(w, err)
+	}
+
+	return h.SendJSON(w, http.StatusOK, dtos.ToEnvironmentDTO(env))
+}
+
+// HandlePut creates or updates an environment (PUT /v1/environments/{name})
+// @Summary Create or update environment
+// @Description Upsert an environment; the path name is authoritative
+// @Tags environments
+// @Accept json
+// @Produce json
+// @Param name path string true "Environment name"
+// @Param environment body dtos.EnvironmentDTO true "Environment data"
+// @Success 200 {object} dtos.UpsertEnvironmentResponse
+// @Failure 400 {object} dtos.BadRequestError
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/environments/{name} [put]
+func (h *EnvironmentHandler) HandlePut(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received upsert environment request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	name, err := h.GetPathParam(r, "name")
+	if err != nil {
+		return h.SendBadRequest(w, err, []string{"name is required"})
+	}
+
+	var dto dtos.EnvironmentDTO
+	if bindErr := h.BindJSON(w, r, &dto); bindErr != nil {
+		return h.SendBadRequest(w, bindErr, []string{"body"})
+	}
+
+	// The path name is authoritative over the body.
+	dto.Name = name
+	env := dtos.FromEnvironmentDTO(dto)
+	if validateErr := env.Validate(); validateErr != nil {
+		return h.SendBadRequest(w, validateErr, []string{"name"})
+	}
+
+	if _, saveErr := h.environmentService.Save(env); saveErr != nil {
+		return h.SendInternalError(w, saveErr)
+	}
+
+	return h.SendJSON(w, http.StatusOK, dtos.UpsertEnvironmentResponse{
+		Message:     "Environment saved successfully",
+		Environment: env.Name,
+	})
+}
+
+// HandleDelete removes an environment (DELETE /v1/environments/{name})
+// @Summary Delete environment
+// @Description Delete an environment (the default environment cannot be deleted)
+// @Tags environments
+// @Accept json
+// @Produce json
+// @Param name path string true "Environment name"
+// @Success 204 "No Content"
+// @Failure 400 {object} dtos.BadRequestError
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/environments/{name} [delete]
+func (h *EnvironmentHandler) HandleDelete(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received delete environment request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	name, err := h.GetPathParam(r, "name")
+	if err != nil {
+		return h.SendBadRequest(w, err, []string{"name is required"})
+	}
+
+	if name == workflow.DefaultEnvironmentName {
+		return h.SendBadRequest(w, fmt.Errorf("the default environment cannot be deleted"), []string{"name"})
+	}
+
+	if delErr := h.environmentService.Delete(name); delErr != nil {
+		return h.SendInternalError(w, delErr)
+	}
+
+	return h.SendJSON(w, http.StatusNoContent, nil)
+}

--- a/internal/handlers/environments.go
+++ b/internal/handlers/environments.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+
+	"ergo.services/ergo/gen"
+	"github.com/open-source-cloud/fuse/internal/dtos"
+	"github.com/open-source-cloud/fuse/internal/services"
+)
+
+const (
+	// EnvironmentsHandlerName is the name of the environments list handler.
+	EnvironmentsHandlerName = "environments_handler"
+	// EnvironmentsHandlerPoolName is the name of the environments list handler pool.
+	EnvironmentsHandlerPoolName = "environments_handler_pool"
+)
+
+type (
+	// EnvironmentsHandlerFactory is the factory for the environments list handler.
+	EnvironmentsHandlerFactory HandlerFactory[*EnvironmentsHandler]
+
+	// EnvironmentsHandler handles the environments collection endpoint.
+	EnvironmentsHandler struct {
+		Handler
+		environmentService services.EnvironmentService
+	}
+)
+
+// NewEnvironmentsHandler creates a new environments list handler factory.
+func NewEnvironmentsHandler(environmentService services.EnvironmentService) *EnvironmentsHandlerFactory {
+	return &EnvironmentsHandlerFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &EnvironmentsHandler{
+				environmentService: environmentService,
+			}
+		},
+	}
+}
+
+// HandleGet lists all declared environments (GET /v1/environments)
+// @Summary List environments
+// @Description Retrieve all declared environments
+// @Tags environments
+// @Accept json
+// @Produce json
+// @Success 200 {object} dtos.EnvironmentListResponse
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/environments [get]
+func (h *EnvironmentsHandler) HandleGet(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received list environments request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	envs, err := h.environmentService.FindAll()
+	if err != nil {
+		return h.SendInternalError(w, err)
+	}
+
+	items := make([]dtos.EnvironmentDTO, len(envs))
+	for i, env := range envs {
+		items[i] = dtos.ToEnvironmentDTO(env)
+	}
+
+	return h.SendJSON(w, http.StatusOK, dtos.EnvironmentListResponse{Items: items})
+}

--- a/internal/handlers/trigger_workflow.go
+++ b/internal/handlers/trigger_workflow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-source-cloud/fuse/internal/dtos"
 	"github.com/open-source-cloud/fuse/internal/idempotency"
 	"github.com/open-source-cloud/fuse/internal/messaging"
+	"github.com/open-source-cloud/fuse/internal/services"
 )
 
 type (
@@ -21,6 +22,7 @@ type (
 		idempotencyStore   idempotency.Store
 		idempotencyTTL     config.IdempotencyConfig
 		defaultEnvironment string
+		environmentService services.EnvironmentService
 	}
 	// TriggerWorkflowHandlerFactory is a factory for creating TriggerWorkflowHandler actors
 	TriggerWorkflowHandlerFactory HandlerFactory[*TriggerWorkflowHandler]
@@ -36,13 +38,14 @@ const (
 )
 
 // NewTriggerWorkflowHandlerFactory creates a new TriggerWorkflowHandlerFactory
-func NewTriggerWorkflowHandlerFactory(store idempotency.Store, cfg *config.Config) *TriggerWorkflowHandlerFactory {
+func NewTriggerWorkflowHandlerFactory(store idempotency.Store, cfg *config.Config, environmentService services.EnvironmentService) *TriggerWorkflowHandlerFactory {
 	return &TriggerWorkflowHandlerFactory{
 		Factory: func() gen.ProcessBehavior {
 			return &TriggerWorkflowHandler{
 				idempotencyStore:   store,
 				idempotencyTTL:     cfg.Idempotency,
 				defaultEnvironment: cfg.Environment,
+				environmentService: environmentService,
 			}
 		},
 	}
@@ -86,6 +89,9 @@ func (h *TriggerWorkflowHandler) HandlePost(from gen.PID, w http.ResponseWriter,
 	environment := req.Environment
 	if environment == "" {
 		environment = h.defaultEnvironment
+	}
+	if !h.environmentService.IsValid(environment) {
+		return h.SendBadRequest(w, fmt.Errorf("unknown environment %q", environment), []string{"environment"})
 	}
 
 	workflowID := workflow.NewID()

--- a/internal/repositories/environment.go
+++ b/internal/repositories/environment.go
@@ -1,0 +1,20 @@
+package repositories
+
+import (
+	"errors"
+
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+// ErrEnvironmentNotFound is returned when an environment is not found.
+var ErrEnvironmentNotFound = errors.New("environment not found")
+
+type (
+	// EnvironmentRepository defines the interface of an environment repository (ADR-0031).
+	EnvironmentRepository interface {
+		FindByID(name string) (*workflow.Environment, error)
+		FindAll() ([]*workflow.Environment, error)
+		Save(env *workflow.Environment) error
+		Delete(name string) error
+	}
+)

--- a/internal/repositories/environment_memory.go
+++ b/internal/repositories/environment_memory.go
@@ -1,0 +1,68 @@
+package repositories
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+// MemoryEnvironmentRepository is an in-memory EnvironmentRepository seeded with the default
+// environment so the registry is never empty (matches the postgres migration seed).
+type MemoryEnvironmentRepository struct {
+	mu           sync.RWMutex
+	environments map[string]*workflow.Environment
+}
+
+// NewMemoryEnvironmentRepository creates a memory environment repository seeded with the
+// default environment.
+func NewMemoryEnvironmentRepository() *MemoryEnvironmentRepository {
+	return &MemoryEnvironmentRepository{
+		environments: map[string]*workflow.Environment{
+			workflow.DefaultEnvironmentName: workflow.NewEnvironment(workflow.DefaultEnvironmentName, "Default environment"),
+		},
+	}
+}
+
+// FindByID finds an environment by name.
+func (r *MemoryEnvironmentRepository) FindByID(name string) (*workflow.Environment, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	env, ok := r.environments[name]
+	if !ok {
+		return nil, ErrEnvironmentNotFound
+	}
+	return env, nil
+}
+
+// FindAll returns all environments sorted by name.
+func (r *MemoryEnvironmentRepository) FindAll() ([]*workflow.Environment, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	envs := make([]*workflow.Environment, 0, len(r.environments))
+	for _, env := range r.environments {
+		envs = append(envs, env)
+	}
+	sort.Slice(envs, func(i, j int) bool { return envs[i].Name < envs[j].Name })
+	return envs, nil
+}
+
+// Save upserts an environment.
+func (r *MemoryEnvironmentRepository) Save(env *workflow.Environment) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.environments[env.Name] = env
+	return nil
+}
+
+// Delete removes an environment by name.
+func (r *MemoryEnvironmentRepository) Delete(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.environments, name)
+	return nil
+}

--- a/internal/repositories/environment_memory_test.go
+++ b/internal/repositories/environment_memory_test.go
@@ -1,0 +1,71 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryEnvironmentRepository(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seeds the default environment", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryEnvironmentRepository()
+
+		env, err := repo.FindByID(workflow.DefaultEnvironmentName)
+
+		require.NoError(t, err)
+		assert.Equal(t, workflow.DefaultEnvironmentName, env.Name)
+	})
+
+	t.Run("Save and FindByID round-trip", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryEnvironmentRepository()
+
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "Staging env")))
+		env, err := repo.FindByID("staging")
+
+		require.NoError(t, err)
+		assert.Equal(t, "staging", env.Name)
+		assert.Equal(t, "Staging env", env.Description)
+	})
+
+	t.Run("FindByID returns ErrEnvironmentNotFound for unknown", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryEnvironmentRepository()
+
+		_, err := repo.FindByID("nope")
+
+		assert.ErrorIs(t, err, ErrEnvironmentNotFound)
+	})
+
+	t.Run("FindAll returns sorted environments including default", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryEnvironmentRepository()
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "")))
+		require.NoError(t, repo.Save(workflow.NewEnvironment("prod", "")))
+
+		envs, err := repo.FindAll()
+
+		require.NoError(t, err)
+		names := make([]string, len(envs))
+		for i, e := range envs {
+			names[i] = e.Name
+		}
+		assert.Equal(t, []string{"default", "prod", "staging"}, names)
+	})
+
+	t.Run("Delete removes an environment", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryEnvironmentRepository()
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "")))
+
+		require.NoError(t, repo.Delete("staging"))
+		_, err := repo.FindByID("staging")
+
+		assert.ErrorIs(t, err, ErrEnvironmentNotFound)
+	})
+}

--- a/internal/repositories/postgres/environment.go
+++ b/internal/repositories/postgres/environment.go
@@ -1,0 +1,90 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+// EnvironmentRepository is a PostgreSQL-backed EnvironmentRepository (ADR-0031). Environments
+// are small metadata, so unlike packages/workflows they are stored entirely in the row (no
+// object store).
+type EnvironmentRepository struct {
+	pool *pgxpool.Pool
+}
+
+// compile-time assertion.
+var _ repositories.EnvironmentRepository = (*EnvironmentRepository)(nil)
+
+// NewEnvironmentRepository creates a new PostgreSQL-backed EnvironmentRepository.
+func NewEnvironmentRepository(pool *pgxpool.Pool) repositories.EnvironmentRepository {
+	return &EnvironmentRepository{pool: pool}
+}
+
+// FindByID retrieves an environment by name.
+func (r *EnvironmentRepository) FindByID(name string) (*workflow.Environment, error) {
+	ctx := context.Background()
+
+	var description string
+	err := r.pool.QueryRow(ctx,
+		`SELECT description FROM environments WHERE name = $1`, name,
+	).Scan(&description)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, repositories.ErrEnvironmentNotFound
+		}
+		return nil, fmt.Errorf("postgres/environment: find by id: %w", err)
+	}
+	return workflow.NewEnvironment(name, description), nil
+}
+
+// FindAll retrieves all environments sorted by name.
+func (r *EnvironmentRepository) FindAll() ([]*workflow.Environment, error) {
+	ctx := context.Background()
+
+	rows, err := r.pool.Query(ctx, `SELECT name, description FROM environments ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("postgres/environment: find all: %w", err)
+	}
+	defer rows.Close()
+
+	envs := make([]*workflow.Environment, 0)
+	for rows.Next() {
+		var name, description string
+		if err := rows.Scan(&name, &description); err != nil {
+			return nil, fmt.Errorf("postgres/environment: scan row: %w", err)
+		}
+		envs = append(envs, workflow.NewEnvironment(name, description))
+	}
+	return envs, rows.Err()
+}
+
+// Save upserts an environment.
+func (r *EnvironmentRepository) Save(env *workflow.Environment) error {
+	ctx := context.Background()
+
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO environments (name, description, created_at, updated_at)
+		VALUES ($1, $2, NOW(), NOW())
+		ON CONFLICT (name) DO UPDATE SET
+			description = EXCLUDED.description,
+			updated_at = NOW()
+	`, env.Name, env.Description)
+	if err != nil {
+		return fmt.Errorf("postgres/environment: upsert %q: %w", env.Name, err)
+	}
+	return nil
+}
+
+// Delete removes an environment by name.
+func (r *EnvironmentRepository) Delete(name string) error {
+	ctx := context.Background()
+	if _, err := r.pool.Exec(ctx, `DELETE FROM environments WHERE name = $1`, name); err != nil {
+		return fmt.Errorf("postgres/environment: delete %q: %w", name, err)
+	}
+	return nil
+}

--- a/internal/repositories/postgres/migrations/000010_create_environments.down.sql
+++ b/internal/repositories/postgres/migrations/000010_create_environments.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS environments;

--- a/internal/repositories/postgres/migrations/000010_create_environments.up.sql
+++ b/internal/repositories/postgres/migrations/000010_create_environments.up.sql
@@ -1,0 +1,15 @@
+-- ADR-0031 Phase 3: first-class environments registry (dev/staging/prod).
+-- Workflow executions reference an environment to scope secret resolution. The 'default'
+-- environment is always present and is what triggers fall back to.
+
+CREATE TABLE environments (
+    id          BIGSERIAL    PRIMARY KEY,
+    name        VARCHAR(128) NOT NULL UNIQUE,
+    description VARCHAR(512) NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO environments (name, description)
+    VALUES ('default', 'Default environment')
+    ON CONFLICT (name) DO NOTHING;

--- a/internal/services/environment_service.go
+++ b/internal/services/environment_service.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+type (
+	// EnvironmentService manages the environments registry (ADR-0031) and validates the
+	// environment a workflow trigger requests.
+	EnvironmentService interface {
+		FindAll() ([]*workflow.Environment, error)
+		FindByID(name string) (*workflow.Environment, error)
+		Save(env *workflow.Environment) (*workflow.Environment, error)
+		Delete(name string) error
+		// IsValid reports whether name is a declared environment. The default environment is
+		// always valid even if the registry has not been seeded.
+		IsValid(name string) bool
+	}
+
+	// DefaultEnvironmentService is the default EnvironmentService implementation.
+	DefaultEnvironmentService struct {
+		repo repositories.EnvironmentRepository
+	}
+)
+
+// NewEnvironmentService returns a new EnvironmentService.
+func NewEnvironmentService(repo repositories.EnvironmentRepository) EnvironmentService {
+	return &DefaultEnvironmentService{repo: repo}
+}
+
+// FindAll returns all declared environments.
+func (s *DefaultEnvironmentService) FindAll() ([]*workflow.Environment, error) {
+	return s.repo.FindAll()
+}
+
+// FindByID returns a single environment by name.
+func (s *DefaultEnvironmentService) FindByID(name string) (*workflow.Environment, error) {
+	return s.repo.FindByID(name)
+}
+
+// Save validates and upserts an environment.
+func (s *DefaultEnvironmentService) Save(env *workflow.Environment) (*workflow.Environment, error) {
+	if err := env.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.repo.Save(env); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+// Delete removes an environment by name.
+func (s *DefaultEnvironmentService) Delete(name string) error {
+	return s.repo.Delete(name)
+}
+
+// IsValid reports whether name is a declared environment (the default is always valid).
+func (s *DefaultEnvironmentService) IsValid(name string) bool {
+	if name == workflow.DefaultEnvironmentName {
+		return true
+	}
+	_, err := s.repo.FindByID(name)
+	return err == nil
+}

--- a/internal/services/environment_service_test.go
+++ b/internal/services/environment_service_test.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newEnvironmentService() EnvironmentService {
+	return NewEnvironmentService(repositories.NewMemoryEnvironmentRepository())
+}
+
+func TestEnvironmentService_IsValid(t *testing.T) {
+	t.Parallel()
+
+	svc := newEnvironmentService()
+	_, err := svc.Save(workflow.NewEnvironment("staging", "Staging"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "default always valid", env: workflow.DefaultEnvironmentName, want: true},
+		{name: "declared environment valid", env: "staging", want: true},
+		{name: "unknown environment invalid", env: "bogus", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, svc.IsValid(tt.env))
+		})
+	}
+}
+
+func TestEnvironmentService_SaveRejectsInvalidName(t *testing.T) {
+	t.Parallel()
+
+	svc := newEnvironmentService()
+
+	_, err := svc.Save(workflow.NewEnvironment("Invalid Name", ""))
+
+	require.Error(t, err)
+}
+
+func TestEnvironmentService_CRUDRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	svc := newEnvironmentService()
+
+	saved, err := svc.Save(workflow.NewEnvironment("prod", "Production"))
+	require.NoError(t, err)
+	assert.Equal(t, "prod", saved.Name)
+
+	found, err := svc.FindByID("prod")
+	require.NoError(t, err)
+	assert.Equal(t, "Production", found.Description)
+
+	require.NoError(t, svc.Delete("prod"))
+	assert.False(t, svc.IsValid("prod"))
+}

--- a/pkg/workflow/environment.go
+++ b/pkg/workflow/environment.go
@@ -1,0 +1,40 @@
+package workflow
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// DefaultEnvironmentName is the environment used when a trigger does not specify one. It is
+// always valid and seeded into the environments registry (ADR-0031).
+const DefaultEnvironmentName = "default"
+
+// environmentNamePattern restricts environment names to lowercase alphanumerics plus -._ so they
+// are safe as secret-store scope keys and URL path segments.
+var environmentNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_.\-]*$`)
+
+// Environment is a declared resolution scope (e.g. dev/staging/prod) referenced by workflow
+// executions to resolve secrets (ADR-0031).
+type Environment struct {
+	Name        string `json:"name" validate:"required"`
+	Description string `json:"description,omitempty"`
+}
+
+// NewEnvironment creates an Environment.
+func NewEnvironment(name, description string) *Environment {
+	return &Environment{Name: name, Description: description}
+}
+
+// Validate checks the environment's fields and name format.
+func (e *Environment) Validate() error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.Struct(e); err != nil {
+		return err
+	}
+	if !environmentNamePattern.MatchString(e.Name) {
+		return fmt.Errorf("invalid environment name %q: must match %s", e.Name, environmentNamePattern.String())
+	}
+	return nil
+}

--- a/pkg/workflow/environment_test.go
+++ b/pkg/workflow/environment_test.go
@@ -1,0 +1,39 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		env     *Environment
+		wantErr bool
+	}{
+		{name: "valid lowercase", env: NewEnvironment("staging", "Staging"), wantErr: false},
+		{name: "valid with separators", env: NewEnvironment("prod-eu_1.2", ""), wantErr: false},
+		{name: "default", env: NewEnvironment(DefaultEnvironmentName, ""), wantErr: false},
+		{name: "empty name", env: NewEnvironment("", "x"), wantErr: true},
+		{name: "uppercase rejected", env: NewEnvironment("Staging", ""), wantErr: true},
+		{name: "leading separator rejected", env: NewEnvironment("-prod", ""), wantErr: true},
+		{name: "spaces rejected", env: NewEnvironment("my env", ""), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.env.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/tests/functional/environment_repository_test.go
+++ b/tests/functional/environment_repository_test.go
@@ -1,0 +1,92 @@
+package functional_test
+
+import (
+	"testing"
+
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func contractTestEnvironmentRepository(t *testing.T, newRepo func() repositories.EnvironmentRepository, reset func()) {
+	t.Helper()
+
+	t.Run("default environment is always present", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+
+		env, err := repo.FindByID(workflow.DefaultEnvironmentName)
+
+		require.NoError(t, err)
+		assert.Equal(t, workflow.DefaultEnvironmentName, env.Name)
+	})
+
+	t.Run("Save and FindByID returns same environment", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "Staging env")))
+		found, err := repo.FindByID("staging")
+
+		require.NoError(t, err)
+		assert.Equal(t, "staging", found.Name)
+		assert.Equal(t, "Staging env", found.Description)
+	})
+
+	t.Run("FindByID returns error for nonexistent environment", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+
+		_, err := repo.FindByID("nonexistent-env")
+
+		assert.ErrorIs(t, err, repositories.ErrEnvironmentNotFound)
+	})
+
+	t.Run("FindAll returns default plus saved environments", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "")))
+		require.NoError(t, repo.Save(workflow.NewEnvironment("prod", "")))
+
+		all, err := repo.FindAll()
+
+		require.NoError(t, err)
+		names := make([]string, len(all))
+		for i, e := range all {
+			names[i] = e.Name
+		}
+		assert.Contains(t, names, workflow.DefaultEnvironmentName)
+		assert.Contains(t, names, "staging")
+		assert.Contains(t, names, "prod")
+	})
+
+	t.Run("Save overwrites description", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "old")))
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "new")))
+
+		found, err := repo.FindByID("staging")
+
+		require.NoError(t, err)
+		assert.Equal(t, "new", found.Description)
+	})
+
+	t.Run("Delete removes environment", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		require.NoError(t, repo.Save(workflow.NewEnvironment("staging", "")))
+
+		require.NoError(t, repo.Delete("staging"))
+
+		_, err := repo.FindByID("staging")
+		assert.ErrorIs(t, err, repositories.ErrEnvironmentNotFound)
+	})
+}
+
+func TestMemoryEnvironmentRepository_Contract(t *testing.T) {
+	contractTestEnvironmentRepository(t, func() repositories.EnvironmentRepository {
+		return repositories.NewMemoryEnvironmentRepository()
+	}, func() {})
+}

--- a/tests/functional/postgres_test.go
+++ b/tests/functional/postgres_test.go
@@ -182,6 +182,20 @@ func TestPostgresPackageRepository_Contract(t *testing.T) {
 	})
 }
 
+// --- Postgres Environment Repository ---
+
+func TestPostgresEnvironmentRepository_Contract(t *testing.T) {
+	pool := setupTestPool(t)
+	contractTestEnvironmentRepository(t, func() repositories.EnvironmentRepository {
+		return postgres.NewEnvironmentRepository(pool)
+	}, func() {
+		// Keep the migration-seeded 'default' row; clear everything else for a clean slate.
+		_, err := pool.Exec(context.Background(),
+			"DELETE FROM environments WHERE name <> 'default'")
+		require.NoError(t, err)
+	})
+}
+
 // --- Postgres Claim Repository ---
 
 func TestPostgresClaimRepository_Contract(t *testing.T) {


### PR DESCRIPTION
## What & why

ADR-0031 Phase 3, deliverable 1 of 4 (**PR B — environments registry**). Stacked on **PR A**
(#83); completes the explicit environments model by making environments **declarable and
validated**.

> Base is `feat/environments-per-execution-scope` (PR #83) so the diff shows only the registry.
> Rebase onto `main` after PR A merges.

## Changes

- **Domain:** `pkg/workflow/Environment` with name-format validation + `DefaultEnvironmentName`.
- **Registry:** `EnvironmentRepository` (memory seeds `default`; Postgres + migration `000010`
  seeding `default`), `EnvironmentService` with `IsValid`, DTOs, and CRUD HTTP API:
  `GET /v1/environments`, `GET/PUT/DELETE /v1/environments/{name}` (the `default` environment
  cannot be deleted). DI wires repo/service/handlers.
- **Strict validation:** the trigger handler rejects an unknown environment with **HTTP 400**
  (`default` always valid).

## Tests

`make lint` clean, `make build` ok, `make test` 665 passing, `make swagger` regenerates cleanly.
Adds domain `Validate`, memory repo, service (`IsValid` + CRUD) tests, and a memory+postgres
functional contract test asserting the seeded `default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)