### PR TITLE
feat(llm): per-context LLM provider keys resolved per environment (ADR-0031 Phase 3, deliverable 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ OBJECT_STORE_DRIVER=memory
 
 # LLM providers (for ai/chat and ai/agent nodes). Each provider is disabled by default.
 # DefaultProvider is used when a node does not specify one.
+# An API key or base URL may be a {{secret:NAME}} reference (ADR-0031), resolved from the
+# SecretStore against the running workflow's environment, e.g.
+#   LLM_OPENAI_API_KEY={{secret:openai_prod_key}}
+# Store the value per environment with: fuse secrets set --env <env> openai_prod_key sk-...
 # LLM_DEFAULT_PROVIDER=ollama
 #
 # Ollama (local dev, no API key needed) — OpenAI-compatible endpoint:

--- a/docs/adr/0031-settings-secrets-and-environments.md
+++ b/docs/adr/0031-settings-secrets-and-environments.md
@@ -121,6 +121,17 @@ drivers with the smallest, most incremental change and gives B and C a stable se
   `SECRETS_DRIVER` selection (`internal/app/di/secrets.go`), and the `fuse secrets` CLI. Infisical
   (Phase 1's read-only external backend) is a fast-follow; credential objects (Phase 2) and
   per-context provider keys (Phase 3) remain scheduled.
+- **Phase 3 — per-context LLM provider keys shipped**: a provider's API key / base URL
+  (`LLM_<PROVIDER>_API_KEY`, `LLM_<PROVIDER>_BASE_URL`) may be a `{{secret:NAME}}` reference
+  resolved from the `SecretStore` against the running workflow's `environment`. `provideLLMRegistry`
+  now builds per-provider `llm.ProviderFactory` closures instead of fixed providers
+  (`internal/app/di/llm.go`): fully-static config is built once (fast path), reference-bearing
+  config resolves and constructs a provider per execution. The `environment` reaches the
+  ai/chat & ai/agent functions via `ExecutionInfo.Environment` (carried on
+  `messaging.ExecuteFunctionMessage`); resolution runs in the function's async goroutine and the
+  resolved key is `Reveal()`'d only into the SDK client, never logged. Different workflows in one
+  process can now use different provider credentials per environment. Credential objects (Phase 2)
+  and Infisical (the read-only external backend) remain scheduled.
 - Supersedes [ADR-0008](0008-settings-environments-and-secrets-management.md) (which recorded the
   problem and deferred the decision).
 - Current state this changes: `internal/app/config/config.go` (env-var secrets),

--- a/internal/actors/workflow_func.go
+++ b/internal/actors/workflow_func.go
@@ -136,7 +136,7 @@ func (a *WorkflowFunc) HandleMessage(from gen.PID, message any) error {
 	result, err := pkg.ExecuteFunction(
 		a,
 		msgPayload.FunctionID,
-		workflow.NewExecutionInfo(msgPayload.WorkflowID, msgPayload.ExecID, input),
+		workflow.NewExecutionInfo(msgPayload.WorkflowID, msgPayload.ExecID, msgPayload.Environment, input),
 	)
 	if err != nil {
 		if result.Output.Status != workflow.FunctionError {

--- a/internal/actors/workflow_handler.go
+++ b/internal/actors/workflow_handler.go
@@ -610,7 +610,7 @@ func (a *WorkflowHandler) handleWorkflowAction(action workflowactions.Action) {
 		a.Log().Info("scheduling retry attempt %d for exec %s in %s",
 			retryAction.Attempt, retryAction.FunctionExecID, retryAction.Delay)
 		workflowPool := WorkflowFuncPoolName(a.workflow.ID())
-		retryMsg := messaging.NewExecuteFunctionMessage(a.workflow.ID(), &retryAction.RunFunctionAction, a.tracingProvider.InjectCarrier(a.spanCtx))
+		retryMsg := messaging.NewExecuteFunctionMessage(a.workflow.ID(), &retryAction.RunFunctionAction, a.workflow.Environment(), a.tracingProvider.InjectCarrier(a.spanCtx))
 		if _, err := a.SendAfter(gen.Atom(workflowPool), retryMsg, retryAction.Delay); err != nil {
 			a.Log().Error("failed to schedule retry: %s", err)
 		}
@@ -646,7 +646,7 @@ func (a *WorkflowHandler) handleWorkflowRunFunctionAction(action workflowactions
 		}
 	}
 
-	execFnMsg := messaging.NewExecuteFunctionMessage(a.workflow.ID(), execAction, a.tracingProvider.InjectCarrier(a.spanCtx))
+	execFnMsg := messaging.NewExecuteFunctionMessage(a.workflow.ID(), execAction, a.workflow.Environment(), a.tracingProvider.InjectCarrier(a.spanCtx))
 	err := a.Send(workflowPool, execFnMsg)
 	if err != nil {
 		a.Log().Error("failed to send execute function message to %s: %s", workflowPool, err)
@@ -991,7 +991,7 @@ func (a *WorkflowHandler) spawnForEachBatch(state *internalworkflow.ForEachState
 	a.iterThreadToForEach[iterThreadID] = state.ExecID.String()
 
 	workflowPool := WorkflowFuncPoolName(a.workflow.ID())
-	execFnMsg := messaging.NewExecuteFunctionMessage(a.workflow.ID(), runAction, a.tracingProvider.InjectCarrier(a.spanCtx))
+	execFnMsg := messaging.NewExecuteFunctionMessage(a.workflow.ID(), runAction, a.workflow.Environment(), a.tracingProvider.InjectCarrier(a.spanCtx))
 	if err := a.Send(workflowPool, execFnMsg); err != nil {
 		a.Log().Error("foreach: failed to dispatch iteration %d: %s", batchIndex, err)
 	}

--- a/internal/app/di/llm.go
+++ b/internal/app/di/llm.go
@@ -1,10 +1,14 @@
 package di
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/open-source-cloud/fuse/internal/app/config"
 	"github.com/open-source-cloud/fuse/internal/llm/providers/anthropic"
 	"github.com/open-source-cloud/fuse/internal/llm/providers/openaicompat"
 	"github.com/open-source-cloud/fuse/pkg/llm"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
 	"github.com/rs/zerolog/log"
 	"go.uber.org/fx"
 )
@@ -30,10 +34,23 @@ type llmProvider struct {
 	conf config.LLMProviderConfig
 }
 
-// provideLLMRegistry builds an llm.Registry from the configured providers.
-// All providers are disabled by default; only enabled ones are registered.
-func provideLLMRegistry(cfg *config.Config) llm.Registry {
-	providers := make(map[string]llm.Provider)
+// providerBuilder constructs a provider from already-resolved connection values.
+type providerBuilder func(name, apiKey, baseURL, model string) llm.Provider
+
+// provideLLMRegistry builds an llm.Registry of per-provider factories from configuration. A
+// provider's APIKey / BaseURL may be a {{secret:NAME}} reference (ADR-0031), in which case its
+// factory resolves the reference from the SecretStore against the running workflow's environment
+// on each call; providers with fully-static config are built once (fast path). All providers are
+// disabled by default; only enabled ones are registered.
+func provideLLMRegistry(cfg *config.Config, secretStore secrets.SecretStore) llm.Registry {
+	factories := make(map[string]llm.ProviderFactory)
+
+	openAICompatBuild := func(name, apiKey, baseURL, model string) llm.Provider {
+		return openaicompat.New(openaicompat.Config{Name: name, APIKey: apiKey, BaseURL: baseURL, Model: model})
+	}
+	anthropicBuild := func(name, apiKey, baseURL, model string) llm.Provider {
+		return anthropic.New(anthropic.Config{Name: name, APIKey: apiKey, BaseURL: baseURL, Model: model})
+	}
 
 	// OpenAI-compatible providers share one implementation, differing only by base URL + key.
 	openAICompat := []llmProvider{
@@ -46,29 +63,53 @@ func provideLLMRegistry(cfg *config.Config) llm.Registry {
 		if !p.conf.Enabled {
 			continue
 		}
-		providers[p.name] = openaicompat.New(openaicompat.Config{
-			Name:    p.name,
-			APIKey:  p.conf.APIKey,
-			BaseURL: p.conf.BaseURL,
-			Model:   p.conf.Model,
-		})
+		factories[p.name] = newProviderFactory(p.name, p.conf, openAICompatBuild, secretStore, cfg.Environment)
 		log.Info().Str("provider", p.name).Str("model", p.conf.Model).Msg("LLM provider registered")
 	}
 
 	// Anthropic uses its own native protocol, so it has a separate implementation.
 	if cfg.LLM.Anthropic.Enabled {
-		providers[providerAnthropic] = anthropic.New(anthropic.Config{
-			Name:    providerAnthropic,
-			APIKey:  cfg.LLM.Anthropic.APIKey,
-			BaseURL: cfg.LLM.Anthropic.BaseURL,
-			Model:   cfg.LLM.Anthropic.Model,
-		})
+		factories[providerAnthropic] = newProviderFactory(providerAnthropic, cfg.LLM.Anthropic, anthropicBuild, secretStore, cfg.Environment)
 		log.Info().Str("provider", providerAnthropic).Str("model", cfg.LLM.Anthropic.Model).Msg("LLM provider registered")
 	}
 
-	if len(providers) == 0 {
+	if len(factories) == 0 {
 		log.Info().Msg("no LLM providers enabled; ai/chat and ai/agent nodes will be unavailable")
 	}
 
-	return llm.NewRegistry(providers, cfg.LLM.DefaultProvider)
+	return llm.NewRegistry(factories, cfg.LLM.DefaultProvider)
+}
+
+// newProviderFactory returns a factory for one provider. When the config has no {{secret:NAME}}
+// references the provider is built once and the factory returns that singleton (preserving the
+// previous static behavior). Otherwise the factory resolves the references per call against the
+// given environment (falling back to defaultEnv when empty) and builds a fresh provider.
+func newProviderFactory(name string, conf config.LLMProviderConfig, build providerBuilder, store secrets.SecretStore, defaultEnv string) llm.ProviderFactory {
+	if !secrets.HasSecretRef(conf.APIKey) && !secrets.HasSecretRef(conf.BaseURL) {
+		p := build(name, conf.APIKey, conf.BaseURL, conf.Model)
+		return func(_ context.Context, _ string) (llm.Provider, error) { return p, nil }
+	}
+
+	return func(ctx context.Context, environment string) (llm.Provider, error) {
+		env := environment
+		if env == "" {
+			env = defaultEnv
+		}
+		resolve := func(refName string) (string, error) {
+			v, err := store.Resolve(ctx, secrets.Scope{Environment: env}, refName)
+			if err != nil {
+				return "", err
+			}
+			return v.Reveal(), nil
+		}
+		apiKey, err := secrets.ReplaceSecretRefs(conf.APIKey, resolve)
+		if err != nil {
+			return nil, fmt.Errorf("llm[%s]: resolve api key for environment %q: %w", name, env, err)
+		}
+		baseURL, err := secrets.ReplaceSecretRefs(conf.BaseURL, resolve)
+		if err != nil {
+			return nil, fmt.Errorf("llm[%s]: resolve base url for environment %q: %w", name, env, err)
+		}
+		return build(name, apiKey, baseURL, conf.Model), nil
+	}
 }

--- a/internal/app/di/llm_test.go
+++ b/internal/app/di/llm_test.go
@@ -1,0 +1,65 @@
+package di
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/internal/app/config"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvideLLMRegistry_ResolvesKeyPerEnvironment(t *testing.T) {
+	ctx := context.Background()
+	store := secrets.NewMemorySecretStore()
+	require.NoError(t, store.Set(ctx, secrets.Scope{Environment: "staging"}, "openai_key", "sk-staging"))
+
+	cfg := &config.Config{
+		Environment: "default",
+		LLM: config.LLMConfig{
+			DefaultProvider: providerOpenAI,
+			OpenAI: config.LLMProviderConfig{
+				Enabled: true,
+				APIKey:  "{{secret:openai_key}}",
+				Model:   "gpt-4o-mini",
+			},
+		},
+	}
+
+	reg := provideLLMRegistry(cfg, store)
+
+	// The secret resolves in the staging environment -> provider builds.
+	prov, err := reg.Get(ctx, "staging", providerOpenAI)
+	require.NoError(t, err)
+	assert.Equal(t, providerOpenAI, prov.Name())
+
+	// An environment without the secret surfaces a resolution error (not a panic).
+	_, err = reg.Get(ctx, "prod", providerOpenAI)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, secrets.ErrSecretNotFound)
+}
+
+func TestProvideLLMRegistry_StaticProviderIsSingleton(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.Config{
+		Environment: "default",
+		LLM: config.LLMConfig{
+			DefaultProvider: providerOllama,
+			Ollama: config.LLMProviderConfig{
+				Enabled: true,
+				BaseURL: "http://localhost:11434/v1",
+				Model:   "llama3",
+			},
+		},
+	}
+
+	reg := provideLLMRegistry(cfg, secrets.NewMemorySecretStore())
+
+	// No secret refs -> the provider is built once and reused (fast path), regardless of env.
+	p1, err := reg.Get(ctx, "staging", providerOllama)
+	require.NoError(t, err)
+	p2, err := reg.Get(ctx, "prod", providerOllama)
+	require.NoError(t, err)
+	assert.Same(t, p1, p2)
+}

--- a/internal/messaging/execute_function.go
+++ b/internal/messaging/execute_function.go
@@ -10,29 +10,33 @@ import (
 
 // ExecuteFunctionMessage defines a ExecuteFunction message
 type ExecuteFunctionMessage struct {
-	WorkflowID workflow.ID     `json:"workflow_id"`
-	ExecID     workflow.ExecID `json:"exec_id"`
-	ThreadID   uint16          `json:"thread_id"`
-	PackageID  string          `json:"package_id"`
-	FunctionID string          `json:"function_id"`
-	Input      map[string]any  `json:"input"`
+	WorkflowID  workflow.ID     `json:"workflow_id"`
+	ExecID      workflow.ExecID `json:"exec_id"`
+	ThreadID    uint16          `json:"thread_id"`
+	PackageID   string          `json:"package_id"`
+	FunctionID  string          `json:"function_id"`
+	Input       map[string]any  `json:"input"`
+	Environment string          `json:"environment"`
 }
 
 // NewExecuteFunctionMessage creates a new ExecuteFunction message.
-// Pass a non-nil traceCarrier to propagate the calling span's context to the worker.
-func NewExecuteFunctionMessage(workflowID workflow.ID, execAction *workflowactions.RunFunctionAction, traceCarrier map[string]string) Message {
+// environment is the workflow's resolution scope (ADR-0031), carried to the function so the
+// engine can resolve per-context capabilities. Pass a non-nil traceCarrier to propagate the
+// calling span's context to the worker.
+func NewExecuteFunctionMessage(workflowID workflow.ID, execAction *workflowactions.RunFunctionAction, environment string, traceCarrier map[string]string) Message {
 	lastSlashIndex := strings.LastIndex(execAction.FunctionID, "/")
 
 	return Message{
 		Type:         ExecuteFunction,
 		TraceCarrier: traceCarrier,
 		Args: ExecuteFunctionMessage{
-			WorkflowID: workflowID,
-			ExecID:     execAction.FunctionExecID,
-			ThreadID:   execAction.ThreadID,
-			PackageID:  execAction.FunctionID[:lastSlashIndex],
-			FunctionID: execAction.FunctionID,
-			Input:      execAction.Args,
+			WorkflowID:  workflowID,
+			ExecID:      execAction.FunctionExecID,
+			ThreadID:    execAction.ThreadID,
+			PackageID:   execAction.FunctionID[:lastSlashIndex],
+			FunctionID:  execAction.FunctionID,
+			Input:       execAction.Args,
+			Environment: environment,
 		},
 	}
 }

--- a/internal/packages/agent_tools_test.go
+++ b/internal/packages/agent_tools_test.go
@@ -83,7 +83,7 @@ func TestInvokeTool_RunsSyncFunctionInline(t *testing.T) {
 	adapter := NewAgentToolRegistry(newTestRegistry(t))
 	input, err := workflow.NewFunctionInputWith(map[string]any{"values": []float64{2, 3}})
 	require.NoError(t, err)
-	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), input)
+	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), "", input)
 
 	res, err := adapter.InvokeTool("fuse/pkg/logic/sum", execInfo)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestInvokeTool_UnknownFunctionReturnsError(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewAgentToolRegistry(newTestRegistry(t))
-	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), nil)
+	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), "", nil)
 
 	_, err := adapter.InvokeTool("does/not/exist", execInfo)
 	require.Error(t, err)

--- a/internal/packages/functions/ai/agent.go
+++ b/internal/packages/functions/ai/agent.go
@@ -70,23 +70,20 @@ func makeAgentFunction(providers llm.Registry, tools ToolRegistry) workflow.Func
 			return workflow.NewFunctionResultError(ErrAgentInputRequired)
 		}
 
-		provider, err := resolveProvider(providers, input.GetStr("provider"))
-		if err != nil {
-			return workflow.NewFunctionResultError(err)
-		}
+		providerName := input.GetStr("provider")
 
 		llmTools, byMangled := buildTools(tools.ListTools(), allowedToolSet(input))
 
 		executor := &agentExecutor{
-			provider:  provider,
-			tools:     tools,
-			byMangled: byMangled,
-			llmTools:  llmTools,
-			model:     input.GetStr("model"),
-			temp:      optionalTemperature(input),
-			maxIters:  clampIterations(input.GetInt("maxIterations")),
-			wfID:      execInfo.WorkflowID,
-			execID:    execInfo.ExecID,
+			tools:       tools,
+			byMangled:   byMangled,
+			llmTools:    llmTools,
+			model:       input.GetStr("model"),
+			temp:        optionalTemperature(input),
+			maxIters:    clampIterations(input.GetInt("maxIterations")),
+			wfID:        execInfo.WorkflowID,
+			execID:      execInfo.ExecID,
+			environment: execInfo.Environment,
 		}
 
 		messages := make([]llm.Message, 0, 4)
@@ -95,11 +92,22 @@ func makeAgentFunction(providers llm.Registry, tools ToolRegistry) workflow.Func
 		}
 		messages = append(messages, llm.Message{Role: llm.RoleUser, Content: userInput})
 
-		// The reasoning loop runs in its own goroutine and reports back via Finish
-		// so the WorkflowFunc pool worker is freed immediately (mirrors ai/chat).
+		// Provider resolution and the reasoning loop run in their own goroutine and report back
+		// via Finish so the WorkflowFunc pool worker is freed immediately (mirrors ai/chat).
+		// Resolution is here too because per-context provider keys (ADR-0031) may hit the secret
+		// store. The provider is resolved ONCE and reused across the loop (stable within a run).
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), agentTimeout)
 			defer cancel()
+
+			provider, err := resolveProvider(ctx, providers, execInfo.Environment, providerName)
+			if err != nil {
+				log.Error().Err(err).Str("provider", providerName).Msg("ai/agent provider resolution failed")
+				execInfo.Finish(errorOutput(fmt.Sprintf("ai/agent: provider resolution failed: %v", err)))
+				return
+			}
+			executor.provider = provider
+
 			execInfo.Finish(executor.run(ctx, messages))
 		}()
 
@@ -109,15 +117,16 @@ func makeAgentFunction(providers llm.Registry, tools ToolRegistry) workflow.Func
 
 // agentExecutor holds the immutable per-run parameters for the reasoning loop.
 type agentExecutor struct {
-	provider  llm.Provider
-	tools     ToolRegistry
-	byMangled map[string]string // mangled tool name -> real function id
-	llmTools  []llm.Tool
-	model     string
-	temp      *float32
-	maxIters  int
-	wfID      workflow.ID
-	execID    workflow.ExecID
+	provider    llm.Provider
+	tools       ToolRegistry
+	byMangled   map[string]string // mangled tool name -> real function id
+	llmTools    []llm.Tool
+	model       string
+	temp        *float32
+	maxIters    int
+	wfID        workflow.ID
+	execID      workflow.ExecID
+	environment string
 }
 
 // run drives the reasoning loop until a final answer, an error, or the iteration
@@ -181,7 +190,7 @@ func (e *agentExecutor) executeToolCall(tc llm.ToolCall) (llm.Message, map[strin
 		return e.toolError(tc, realID, args, fmt.Sprintf("failed to build tool input: %v", err))
 	}
 
-	result, err := e.tools.InvokeTool(realID, workflow.NewExecutionInfo(e.wfID, e.execID, nestedInput))
+	result, err := e.tools.InvokeTool(realID, workflow.NewExecutionInfo(e.wfID, e.execID, e.environment, nestedInput))
 	if err != nil {
 		return e.toolError(tc, realID, args, err.Error())
 	}

--- a/internal/packages/functions/ai/agent_test.go
+++ b/internal/packages/functions/ai/agent_test.go
@@ -96,7 +96,7 @@ var randDescriptor = ToolDescriptor{
 }
 
 func registryWith(prov llm.Provider) llm.Registry {
-	return llm.NewRegistry(map[string]llm.Provider{prov.Name(): prov}, prov.Name())
+	return llm.NewStaticRegistry(map[string]llm.Provider{prov.Name(): prov}, prov.Name())
 }
 
 func runAgent(t *testing.T, providers llm.Registry, tools ToolRegistry, input map[string]any) (workflow.FunctionResult, workflow.FunctionOutput) {
@@ -105,7 +105,7 @@ func runAgent(t *testing.T, providers llm.Registry, tools ToolRegistry, input ma
 	require.NoError(t, err)
 
 	done := make(chan workflow.FunctionOutput, 1)
-	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), fnInput)
+	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), "", fnInput)
 	execInfo.Finish = func(out workflow.FunctionOutput) { done <- out }
 
 	res, err := makeAgentFunction(providers, tools)(execInfo)
@@ -204,11 +204,13 @@ func TestAgent_MissingInputReturnsSyncError(t *testing.T) {
 	assert.Equal(t, workflow.FunctionError, res.Output.Status)
 }
 
-func TestAgent_UnknownProviderReturnsSyncError(t *testing.T) {
+func TestAgent_UnknownProviderDeliveredAsErrorOutput(t *testing.T) {
+	// Provider resolution happens inside the async goroutine (it may hit the secret store for
+	// per-context keys), so an unknown provider surfaces as an async FunctionError, not a sync one.
 	prov := &scriptedProvider{name: "stub"}
-	res, _ := runAgent(t, registryWith(prov), &fakeToolRegistry{}, map[string]any{"input": "hi", "provider": "nope"})
-	assert.False(t, res.Async)
-	assert.Equal(t, workflow.FunctionError, res.Output.Status)
+	res, out := runAgent(t, registryWith(prov), &fakeToolRegistry{}, map[string]any{"input": "hi", "provider": "nope"})
+	assert.True(t, res.Async)
+	assert.Equal(t, workflow.FunctionError, out.Status)
 }
 
 func TestAgent_UnknownToolFedBackAndContinues(t *testing.T) {

--- a/internal/packages/functions/ai/chat.go
+++ b/internal/packages/functions/ai/chat.go
@@ -93,10 +93,7 @@ func makeChatFunction(providers llm.Registry) workflow.Function {
 			return workflow.NewFunctionResultError(ErrInputRequired)
 		}
 
-		provider, err := resolveProvider(providers, input.GetStr("provider"))
-		if err != nil {
-			return workflow.NewFunctionResultError(err)
-		}
+		providerName := input.GetStr("provider")
 
 		messages := make([]llm.Message, 0, 2)
 		if systemPrompt := input.GetStr("systemPrompt"); systemPrompt != "" {
@@ -110,11 +107,20 @@ func makeChatFunction(providers llm.Registry) workflow.Function {
 			Temperature: optionalTemperature(input),
 		}
 
-		// The completion runs in its own goroutine and reports back via Finish so the
-		// WorkflowFunc pool worker is freed immediately (mirrors logic/timer).
+		// Provider resolution and the completion run in their own goroutine and report back via
+		// Finish so the WorkflowFunc pool worker is freed immediately (mirrors logic/timer).
+		// Resolution is in here too because per-context provider keys (ADR-0031) may hit the
+		// secret store, which is I/O we must keep off the pool worker.
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), chatTimeout)
 			defer cancel()
+
+			provider, err := resolveProvider(ctx, providers, execInfo.Environment, providerName)
+			if err != nil {
+				log.Error().Err(err).Str("provider", providerName).Msg("ai/chat provider resolution failed")
+				execInfo.Finish(workflow.NewFunctionOutput(workflow.FunctionError, map[string]any{"error": err.Error()}))
+				return
+			}
 
 			resp, err := provider.Chat(ctx, req)
 			if err != nil {
@@ -137,12 +143,13 @@ func makeChatFunction(providers llm.Registry) workflow.Function {
 	}
 }
 
-// resolveProvider returns the named provider, or the registry default when name is empty.
-func resolveProvider(providers llm.Registry, name string) (llm.Provider, error) {
+// resolveProvider returns the named provider, or the registry default when name is empty, built
+// for the given environment so per-context keys (ADR-0031) resolve against the running workflow.
+func resolveProvider(ctx context.Context, providers llm.Registry, environment, name string) (llm.Provider, error) {
 	if name != "" {
-		return providers.Get(name)
+		return providers.Get(ctx, environment, name)
 	}
-	return providers.Default()
+	return providers.Default(ctx, environment)
 }
 
 // optionalTemperature extracts the temperature input if present and numeric.

--- a/internal/packages/functions/ai/chat_test.go
+++ b/internal/packages/functions/ai/chat_test.go
@@ -37,7 +37,7 @@ func runChat(t *testing.T, reg llm.Registry, input map[string]any) (workflow.Fun
 	require.NoError(t, err)
 
 	done := make(chan workflow.FunctionOutput, 1)
-	execInfo := workflow.NewExecutionInfo("wf-1", "exec-1", fnInput)
+	execInfo := workflow.NewExecutionInfo("wf-1", "exec-1", "", fnInput)
 	execInfo.Finish = func(out workflow.FunctionOutput) { done <- out }
 
 	res, err := makeChatFunction(reg)(execInfo)
@@ -63,7 +63,7 @@ func TestChat_SuccessDeliversOutputViaFinish(t *testing.T) {
 			Usage:   llm.Usage{PromptTokens: 3, CompletionTokens: 4, TotalTokens: 7},
 		},
 	}
-	reg := llm.NewRegistry(map[string]llm.Provider{"stub": prov}, "stub")
+	reg := llm.NewStaticRegistry(map[string]llm.Provider{"stub": prov}, "stub")
 
 	res, out := runChat(t, reg, map[string]any{
 		"input":        "what is the answer?",
@@ -84,22 +84,56 @@ func TestChat_SuccessDeliversOutputViaFinish(t *testing.T) {
 }
 
 func TestChat_MissingInputReturnsSyncError(t *testing.T) {
-	reg := llm.NewRegistry(map[string]llm.Provider{"stub": &stubProvider{name: "stub"}}, "stub")
+	reg := llm.NewStaticRegistry(map[string]llm.Provider{"stub": &stubProvider{name: "stub"}}, "stub")
 	res, _ := runChat(t, reg, map[string]any{"input": ""})
 	assert.False(t, res.Async)
 	assert.Equal(t, workflow.FunctionError, res.Output.Status)
 }
 
-func TestChat_UnknownProviderReturnsSyncError(t *testing.T) {
-	reg := llm.NewRegistry(map[string]llm.Provider{"stub": &stubProvider{name: "stub"}}, "stub")
-	res, _ := runChat(t, reg, map[string]any{"input": "hi", "provider": "nope"})
-	assert.False(t, res.Async)
-	assert.Equal(t, workflow.FunctionError, res.Output.Status)
+func TestChat_UnknownProviderDeliveredAsErrorOutput(t *testing.T) {
+	// Provider resolution happens inside the async goroutine (it may hit the secret store for
+	// per-context keys), so an unknown provider surfaces as an async FunctionError, not a sync one.
+	reg := llm.NewStaticRegistry(map[string]llm.Provider{"stub": &stubProvider{name: "stub"}}, "stub")
+	res, out := runChat(t, reg, map[string]any{"input": "hi", "provider": "nope"})
+	assert.True(t, res.Async)
+	assert.Equal(t, workflow.FunctionError, out.Status)
+}
+
+func TestChat_ResolvesProviderForExecutionEnvironment(t *testing.T) {
+	// A factory registry returns a different provider per environment; the chat function must
+	// resolve using execInfo.Environment so per-context keys (ADR-0031) bind to the right env.
+	staging := &stubProvider{name: "staging", resp: llm.ChatResponse{Message: llm.Message{Content: "from staging"}}}
+	prod := &stubProvider{name: "prod", resp: llm.ChatResponse{Message: llm.Message{Content: "from prod"}}}
+	reg := llm.NewRegistry(map[string]llm.ProviderFactory{
+		"openai": func(_ context.Context, env string) (llm.Provider, error) {
+			if env == "staging" {
+				return staging, nil
+			}
+			return prod, nil
+		},
+	}, "openai")
+
+	fnInput, err := workflow.NewFunctionInputWith(map[string]any{"input": "hi"})
+	require.NoError(t, err)
+	done := make(chan workflow.FunctionOutput, 1)
+	execInfo := workflow.NewExecutionInfo("wf-1", "exec-1", "staging", fnInput)
+	execInfo.Finish = func(out workflow.FunctionOutput) { done <- out }
+
+	res, err := makeChatFunction(reg)(execInfo)
+	require.NoError(t, err)
+	require.True(t, res.Async)
+	select {
+	case out := <-done:
+		assert.Equal(t, workflow.FunctionSuccess, out.Status)
+		assert.Equal(t, "from staging", out.Data["output"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async Finish")
+	}
 }
 
 func TestChat_ProviderErrorDeliveredAsErrorOutput(t *testing.T) {
 	prov := &stubProvider{name: "stub", err: errors.New("boom")}
-	reg := llm.NewRegistry(map[string]llm.Provider{"stub": prov}, "stub")
+	reg := llm.NewStaticRegistry(map[string]llm.Provider{"stub": prov}, "stub")
 	res, out := runChat(t, reg, map[string]any{"input": "hi"})
 	assert.True(t, res.Async)
 	assert.Equal(t, workflow.FunctionError, out.Status)

--- a/internal/packages/transport/internal_test.go
+++ b/internal/packages/transport/internal_test.go
@@ -62,7 +62,7 @@ func TestExecuteSync_RunsFunctionWithoutHandle(t *testing.T) {
 	}
 	tr := NewInternalFunctionTransport(fn)
 
-	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), nil)
+	execInfo := workflow.NewExecutionInfo("wf-1", workflow.NewExecID(1), "", nil)
 	res, err := tr.ExecuteSync(execInfo)
 	require.NoError(t, err)
 	require.True(t, called, "the function should run")

--- a/pkg/llm/registry.go
+++ b/pkg/llm/registry.go
@@ -1,6 +1,9 @@
 package llm
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // ErrProviderNotFound is returned when a requested provider is not registered.
 var ErrProviderNotFound = fmt.Errorf("llm provider not found")
@@ -8,53 +11,70 @@ var ErrProviderNotFound = fmt.Errorf("llm provider not found")
 // ErrNoDefaultProvider is returned when no default provider is configured.
 var ErrNoDefaultProvider = fmt.Errorf("no default llm provider configured")
 
-// Registry resolves configured LLM providers by name.
+// ProviderFactory builds a Provider for a given resolution environment (ADR-0031). It is called
+// per execution so providers whose API key / base URL are secret references resolve against the
+// running workflow's environment; factories for fully-static config return a prebuilt singleton.
+type ProviderFactory func(ctx context.Context, environment string) (Provider, error)
+
+// Registry resolves configured LLM providers by name, scoped to an environment.
 type Registry interface {
-	// Get returns the provider registered under name.
-	Get(name string) (Provider, error)
-	// Default returns the configured default provider.
-	Default() (Provider, error)
+	// Get returns the provider registered under name, built for the given environment.
+	Get(ctx context.Context, environment, name string) (Provider, error)
+	// Default returns the configured default provider, built for the given environment.
+	Default(ctx context.Context, environment string) (Provider, error)
 	// List returns the names of all registered providers.
 	List() []string
 }
 
 // memoryRegistry is the default in-memory Registry implementation.
 type memoryRegistry struct {
-	providers   map[string]Provider
+	factories   map[string]ProviderFactory
 	defaultName string
 }
 
-// NewRegistry builds a Registry from the given providers. defaultName selects
-// the provider returned by Default; it may be empty if no default is desired.
-func NewRegistry(providers map[string]Provider, defaultName string) Registry {
-	p := make(map[string]Provider, len(providers))
-	for name, prov := range providers {
-		p[name] = prov
+// NewRegistry builds a Registry from per-provider factories. defaultName selects the provider
+// returned by Default; it may be empty if no default is desired.
+func NewRegistry(factories map[string]ProviderFactory, defaultName string) Registry {
+	f := make(map[string]ProviderFactory, len(factories))
+	for name, factory := range factories {
+		f[name] = factory
 	}
-	return &memoryRegistry{providers: p, defaultName: defaultName}
+	return &memoryRegistry{factories: f, defaultName: defaultName}
 }
 
-// Get returns the provider registered under name.
-func (r *memoryRegistry) Get(name string) (Provider, error) {
-	prov, ok := r.providers[name]
+// NewStaticRegistry builds a Registry from already-constructed providers, ignoring the
+// environment. It is the fast path for fully-static configuration and the convenience
+// constructor for tests.
+func NewStaticRegistry(providers map[string]Provider, defaultName string) Registry {
+	factories := make(map[string]ProviderFactory, len(providers))
+	for name, prov := range providers {
+		p := prov
+		factories[name] = func(_ context.Context, _ string) (Provider, error) { return p, nil }
+	}
+	return NewRegistry(factories, defaultName)
+}
+
+// Get returns the provider registered under name, built for the given environment.
+func (r *memoryRegistry) Get(ctx context.Context, environment, name string) (Provider, error) {
+	factory, ok := r.factories[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrProviderNotFound, name)
 	}
-	return prov, nil
+	return factory(ctx, environment)
 }
 
-// Default returns the configured default provider.
-func (r *memoryRegistry) Default() (Provider, error) {
+// Default returns the configured default provider, built for the given environment.
+func (r *memoryRegistry) Default(ctx context.Context, environment string) (Provider, error) {
 	if r.defaultName == "" {
 		return nil, ErrNoDefaultProvider
 	}
-	return r.Get(r.defaultName)
+	return r.Get(ctx, environment, r.defaultName)
 }
 
 // List returns the names of all registered providers.
 func (r *memoryRegistry) List() []string {
-	names := make([]string, 0, len(r.providers))
-	for name := range r.providers {
+	names := make([]string, 0, len(r.factories))
+	for name := range r.factories {
 		names = append(names, name)
 	}
 	return names

--- a/pkg/llm/registry_test.go
+++ b/pkg/llm/registry_test.go
@@ -18,16 +18,16 @@ func (s stubProvider) Chat(_ context.Context, _ llm.ChatRequest) (llm.ChatRespon
 }
 
 func TestRegistry_GetAndDefault(t *testing.T) {
-	reg := llm.NewRegistry(map[string]llm.Provider{
+	reg := llm.NewStaticRegistry(map[string]llm.Provider{
 		"openai": stubProvider{name: "openai"},
 		"ollama": stubProvider{name: "ollama"},
 	}, "ollama")
 
-	got, err := reg.Get("openai")
+	got, err := reg.Get(context.Background(), "", "openai")
 	require.NoError(t, err)
 	assert.Equal(t, "openai", got.Name())
 
-	def, err := reg.Default()
+	def, err := reg.Default(context.Background(), "")
 	require.NoError(t, err)
 	assert.Equal(t, "ollama", def.Name())
 
@@ -35,13 +35,31 @@ func TestRegistry_GetAndDefault(t *testing.T) {
 }
 
 func TestRegistry_GetUnknownErrors(t *testing.T) {
-	reg := llm.NewRegistry(map[string]llm.Provider{}, "")
-	_, err := reg.Get("nope")
+	reg := llm.NewStaticRegistry(map[string]llm.Provider{}, "")
+	_, err := reg.Get(context.Background(), "", "nope")
 	assert.ErrorIs(t, err, llm.ErrProviderNotFound)
 }
 
 func TestRegistry_NoDefaultErrors(t *testing.T) {
-	reg := llm.NewRegistry(map[string]llm.Provider{"openai": stubProvider{name: "openai"}}, "")
-	_, err := reg.Default()
+	reg := llm.NewStaticRegistry(map[string]llm.Provider{"openai": stubProvider{name: "openai"}}, "")
+	_, err := reg.Default(context.Background(), "")
 	assert.ErrorIs(t, err, llm.ErrNoDefaultProvider)
+}
+
+// TestRegistry_FactoryDispatchesEnvironment proves the environment is threaded through to the
+// factory, so a provider can be built per execution environment (ADR-0031 per-context keys).
+func TestRegistry_FactoryDispatchesEnvironment(t *testing.T) {
+	reg := llm.NewRegistry(map[string]llm.ProviderFactory{
+		"openai": func(_ context.Context, environment string) (llm.Provider, error) {
+			return stubProvider{name: "openai-" + environment}, nil
+		},
+	}, "openai")
+
+	staging, err := reg.Get(context.Background(), "staging", "openai")
+	require.NoError(t, err)
+	assert.Equal(t, "openai-staging", staging.Name())
+
+	prod, err := reg.Default(context.Background(), "prod")
+	require.NoError(t, err)
+	assert.Equal(t, "openai-prod", prod.Name())
 }

--- a/pkg/workflow/execution_info.go
+++ b/pkg/workflow/execution_info.go
@@ -1,11 +1,12 @@
 package workflow
 
 // NewExecutionInfo creates a new ExecutionInfo to pass to an executable function
-func NewExecutionInfo(workflowID ID, execID ExecID, input *FunctionInput) *ExecutionInfo {
+func NewExecutionInfo(workflowID ID, execID ExecID, environment string, input *FunctionInput) *ExecutionInfo {
 	return &ExecutionInfo{
-		WorkflowID: workflowID,
-		ExecID:     execID,
-		Input:      input,
+		WorkflowID:  workflowID,
+		ExecID:      execID,
+		Environment: environment,
+		Input:       input,
 	}
 }
 
@@ -13,6 +14,10 @@ func NewExecutionInfo(workflowID ID, execID ExecID, input *FunctionInput) *Execu
 type ExecutionInfo struct {
 	WorkflowID ID
 	ExecID     ExecID
-	Input      *FunctionInput
-	Finish     func(FunctionOutput)
+	// Environment is the resolution scope (ADR-0031) of the running workflow. It lets the engine
+	// resolve per-context capabilities (e.g. LLM provider keys) without the function touching the
+	// secret store; it is scope data, not a secret.
+	Environment string
+	Input       *FunctionInput
+	Finish      func(FunctionOutput)
 }


### PR DESCRIPTION
## What & why

ADR-0031 Phase 3, **deliverable 2 of 4** (per-context LLM provider keys). Depends on
deliverable 1's per-execution `environment` scope — **stacked on PR #83**
(`feat/environments-per-execution-scope`).

> Base is PR #83 so the diff shows only this deliverable. Retarget to `main` after #83 merges.

**Problem:** the LLM provider registry was built once at startup with static keys, so every
workflow in a process shared the same provider credentials. **Now** a provider's API key /
base-URL may be a `{{secret:NAME}}` reference resolved from the `SecretStore` against the running
workflow's `environment` — `staging` and `prod` workflows can use different keys from one process.

## Changes

- **`pkg/llm`** — factory-based `Registry`: `Get`/`Default` take `(ctx, environment)`;
  `NewRegistry(map[string]ProviderFactory, …)`; `NewStaticRegistry` shim for the static fast path
  and tests.
- **`di/llm`** — `provideLLMRegistry` builds per-provider factories. Fully-static config → built
  once (singleton fast path, **zero behavior change**); `{{secret:}}`-bearing config → resolves via
  `SecretStore` + `ReplaceSecretRefs` and builds a fresh provider per call. Resolved keys are
  `Reveal()`'d only into the SDK client, **never logged**.
- **Environment threading** — `ExecutionInfo.Environment` (carried on `ExecuteFunctionMessage`, set
  from `a.workflow.Environment()` at the 3 handler dispatch sites). `ai/chat` & `ai/agent` resolve
  the provider **inside their async goroutine** (keeps secret I/O off the pool worker) using
  `execInfo.Environment`; the agent resolves once and reuses it across the loop; tool/sub
  `ExecutionInfo` inherits the environment.

## Behavior note
Unknown-provider now surfaces as an **async** `FunctionError` (resolution moved into the goroutine),
not a sync error — the two affected tests were updated accordingly.

## Tests
`make lint` clean, `make build` ok, `make test` **642 passing**, `make swagger` regenerates cleanly.
Adds: registry factory env-dispatch test, `ai/chat` env-routing test, and `di/llm` tests for
per-environment secret resolution + the singleton fast path. Backward compat (all-literal config +
memory store) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)