### PR TITLE
feat(secrets): credential objects registry — typed metadata + per-env values (ADR-0031 Phase 2, deliverable 3 PR 1)

### DIFF
--- a/internal/actors/mux_worker.go
+++ b/internal/actors/mux_worker.go
@@ -126,6 +126,26 @@ func NewWorkers() *Workers {
 				},
 			},
 			{
+				Name:    handlers.CredentialsHandlerName,
+				Pattern: "/v1/credentials",
+				Methods: []string{"GET"},
+				Timeout: 10 * time.Second,
+				PoolConfig: WorkerPoolConfig{
+					Name:     handlers.CredentialsHandlerPoolName,
+					PoolSize: 3,
+				},
+			},
+			{
+				Name:    handlers.CredentialHandlerName,
+				Pattern: "/v1/credentials/{id}",
+				Methods: []string{"GET", "PUT", "DELETE"},
+				Timeout: 10 * time.Second,
+				PoolConfig: WorkerPoolConfig{
+					Name:     handlers.CredentialHandlerPoolName,
+					PoolSize: 3,
+				},
+			},
+			{
 				Name:    handlers.ListSchemaVersionsHandlerName,
 				Pattern: "/v1/schemas/{schemaID}/versions",
 				Methods: []string{"GET"},

--- a/internal/app/cli/credentials.go
+++ b/internal/app/cli/credentials.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-source-cloud/fuse/internal/app/config"
+	"github.com/open-source-cloud/fuse/internal/app/di"
+	"github.com/open-source-cloud/fuse/internal/logging"
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/internal/repositories/postgres"
+	"github.com/open-source-cloud/fuse/internal/services"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+// credentialsEnvFlag scopes credential value operations to an environment (defaults to FUSE_ENVIRONMENT).
+var credentialsEnvFlag string
+
+// credentialsTypeFlag sets the credential type on `credentials set` (defaults to "custom").
+var credentialsTypeFlag string
+
+func newCredentialsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "credentials",
+		Short: "Manage credentials (typed groups of secret values) in the configured store",
+		Long: "Set, list, and delete credentials. A credential's field values are stored in the " +
+			"SECRETS_DRIVER backend at cred/<id>/<field>, per environment (ADR-0031). Requires " +
+			"driver=memory or driver=postgres for writes.",
+	}
+	cmd.PersistentFlags().StringVar(&credentialsEnvFlag, "env", "", "Environment scope (defaults to FUSE_ENVIRONMENT)")
+	cmd.AddCommand(newCredentialsSetCommand(), newCredentialsListCommand(), newCredentialsDeleteCommand())
+	return cmd
+}
+
+func newCredentialsSetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <id> <field> <value>",
+		Short: "Set (or rotate) a credential field value",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(_ *cobra.Command, args []string) error {
+			id, field, value := args[0], args[1], args[2]
+			return runCredentialsApp(func(_ context.Context, svc services.CredentialService, env string) error {
+				cred := workflow.NewCredential(id, credentialsTypeFlag, "", nil)
+				if _, err := svc.Save(cred, map[string]string{field: value}, env); err != nil {
+					return err
+				}
+				log.Info().Str("environment", env).Str("credential", id).Str("field", field).Msg("credential field set")
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&credentialsTypeFlag, "type", "custom", "Credential type (free-form, e.g. openai)")
+	return cmd
+}
+
+func newCredentialsListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List credentials (ids, type, and field names; never values)",
+		Args:  cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return runCredentialsApp(func(_ context.Context, svc services.CredentialService, _ string) error {
+				creds, err := svc.FindAll()
+				if err != nil {
+					return err
+				}
+				if len(creds) == 0 {
+					fmt.Println("(no credentials)")
+					return nil
+				}
+				for _, c := range creds {
+					fmt.Printf("  - %s (type=%s) fields=%v\n", c.ID, c.Type, c.Fields)
+				}
+				return nil
+			})
+		},
+	}
+}
+
+func newCredentialsDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a credential and its field values in the environment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			id := args[0]
+			return runCredentialsApp(func(_ context.Context, svc services.CredentialService, env string) error {
+				if err := svc.Delete(id, env); err != nil {
+					return err
+				}
+				log.Info().Str("environment", env).Str("credential", id).Msg("credential deleted")
+				return nil
+			})
+		},
+	}
+}
+
+// credentialsAppParams are the dependencies the credentials CLI action needs. Pool is optional so
+// the command works under the memory driver (no database).
+type credentialsAppParams struct {
+	fx.In
+	LC    fx.Lifecycle
+	Cfg   *config.Config
+	Store secrets.SecretStore
+	Pool  *pgxpool.Pool `optional:"true"`
+	SD    fx.Shutdowner
+}
+
+// runCredentialsApp boots the minimal DI graph (config + database + secrets), builds a
+// CredentialService over the selected secret backend, runs the admin action, and exits.
+func runCredentialsApp(action func(context.Context, services.CredentialService, string) error) error {
+	var actionErr error
+	app := fx.New(
+		di.CommonModule,
+		di.DatabaseModule,
+		di.SecretsModule,
+		fx.Invoke(func(p credentialsAppParams) {
+			p.LC.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					repo := credentialRepoFor(p.Cfg, p.Pool)
+					svc := services.NewCredentialService(repo, p.Store)
+					env := credentialsEnvFlag
+					if env == "" {
+						env = p.Cfg.Environment
+					}
+					actionErr = action(ctx, svc, env)
+					go func() { _ = p.SD.Shutdown() }()
+					return nil
+				},
+			})
+		}),
+		fx.WithLogger(logging.NewFxLogger()),
+	)
+	app.Run()
+	if err := app.Err(); err != nil {
+		return err
+	}
+	return actionErr
+}
+
+// credentialRepoFor selects the credential metadata repository matching the database driver.
+func credentialRepoFor(cfg *config.Config, pool *pgxpool.Pool) repositories.CredentialRepository {
+	if cfg.Database.Driver == config.DBDriverPostgres && pool != nil {
+		return postgres.NewCredentialRepository(pool)
+	}
+	return repositories.NewMemoryCredentialRepository()
+}

--- a/internal/app/cli/root.go
+++ b/internal/app/cli/root.go
@@ -51,6 +51,7 @@ func newRoot() *cobra.Command {
 	rootCmd.AddCommand(newMigrateCommand())
 	rootCmd.AddCommand(newSeedCommand())
 	rootCmd.AddCommand(newSecretsCommand())
+	rootCmd.AddCommand(newCredentialsCommand())
 	rootCmd.AddCommand(newWorkflowCommand())
 	rootCmd.AddCommand(newMermaidCommand())
 	rootCmd.AddCommand(newHealthCommand())

--- a/internal/app/di/actors.go
+++ b/internal/app/di/actors.go
@@ -35,6 +35,8 @@ type workerHandlerRegistrationParams struct {
 	GetSchemaVersionHandlerFactory      *handlers.GetSchemaVersionHandlerFactory
 	ActivateSchemaVersionHandlerFactory *handlers.ActivateSchemaVersionHandlerFactory
 	RollbackSchemaHandlerFactory        *handlers.RollbackSchemaHandlerFactory
+	CredentialsHandlerFactory           *handlers.CredentialsHandlerFactory
+	CredentialHandlerFactory            *handlers.CredentialHandlerFactory
 }
 
 // newWorkers builds the HTTP worker registry with all handler factories registered.
@@ -65,6 +67,8 @@ func newWorkers(p workerHandlerRegistrationParams) *actors.Workers {
 	w.AddFactory(handlers.GetSchemaVersionHandlerName, p.GetSchemaVersionHandlerFactory.Factory)
 	w.AddFactory(handlers.ActivateSchemaVersionHandlerName, p.ActivateSchemaVersionHandlerFactory.Factory)
 	w.AddFactory(handlers.RollbackSchemaHandlerName, p.RollbackSchemaHandlerFactory.Factory)
+	w.AddFactory(handlers.CredentialsHandlerName, p.CredentialsHandlerFactory.Factory)
+	w.AddFactory(handlers.CredentialHandlerName, p.CredentialHandlerFactory.Factory)
 	return w
 }
 
@@ -95,6 +99,8 @@ var WorkerModule = fx.Module(
 		handlers.NewGetSchemaVersionHandlerFactory,
 		handlers.NewActivateSchemaVersionHandlerFactory,
 		handlers.NewRollbackSchemaHandlerFactory,
+		handlers.NewCredentialsHandler,
+		handlers.NewCredentialHandler,
 		newWorkers,
 	),
 )

--- a/internal/app/di/repos.go
+++ b/internal/app/di/repos.go
@@ -22,6 +22,7 @@ var RepoModule = fx.Module(
 		provideAwakeableRepository,
 		provideClaimRepository,
 		provideTraceRepository,
+		provideCredentialRepository,
 	),
 )
 
@@ -84,6 +85,15 @@ func provideClaimRepository(p repoParams) repositories.ClaimRepository {
 	}
 	log.Debug().Msg("using memory claim repository (no-op)")
 	return repositories.NewMemoryClaimRepository()
+}
+
+func provideCredentialRepository(p repoParams) repositories.CredentialRepository {
+	if p.Config.Database.Driver == config.DBDriverPostgres && p.Pool != nil {
+		log.Debug().Msg("using postgres credential repository")
+		return postgres.NewCredentialRepository(p.Pool)
+	}
+	log.Debug().Msg("using memory credential repository")
+	return repositories.NewMemoryCredentialRepository()
 }
 
 func provideTraceRepository(p repoParams) repositories.TraceRepository {

--- a/internal/app/di/services.go
+++ b/internal/app/di/services.go
@@ -28,6 +28,7 @@ var ServicesModule = fx.Module(
 		),
 		services.NewGraphService,
 		services.NewPackageService,
+		services.NewCredentialService,
 	),
 	fx.Invoke(bindSchemaReplicationPublisher),
 )

--- a/internal/dtos/credential.go
+++ b/internal/dtos/credential.go
@@ -1,0 +1,36 @@
+package dtos
+
+import "github.com/open-source-cloud/fuse/pkg/workflow"
+
+// CredentialDTO is the read shape of a credential. It carries metadata only — field values are
+// never returned (ADR-0031).
+type CredentialDTO struct {
+	ID          string   `json:"id" example:"openai-prod"`
+	Type        string   `json:"type" example:"openai"`
+	Description string   `json:"description,omitempty" example:"Production OpenAI credentials"`
+	Fields      []string `json:"fields"`
+}
+
+// UpsertCredentialRequest is the write shape. Field values are write-only and are stored in the
+// SecretStore for the target environment; they never appear in a read response.
+type UpsertCredentialRequest struct {
+	Type        string            `json:"type" example:"openai"`
+	Description string            `json:"description,omitempty"`
+	Fields      map[string]string `json:"fields"`
+}
+
+// CredentialListResponse represents a list of credentials (metadata only).
+type CredentialListResponse struct {
+	Items []CredentialDTO `json:"items"`
+}
+
+// UpsertCredentialResponse represents a credential upsert response.
+type UpsertCredentialResponse struct {
+	Message    string `json:"message" example:"Credential saved successfully"`
+	Credential string `json:"credential" example:"openai-prod"`
+}
+
+// ToCredentialDTO converts credential metadata to its read DTO (never includes values).
+func ToCredentialDTO(c *workflow.Credential) CredentialDTO {
+	return CredentialDTO{ID: c.ID, Type: c.Type, Description: c.Description, Fields: c.Fields}
+}

--- a/internal/handlers/credential.go
+++ b/internal/handlers/credential.go
@@ -1,0 +1,157 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"ergo.services/ergo/gen"
+	"github.com/open-source-cloud/fuse/internal/app/config"
+	"github.com/open-source-cloud/fuse/internal/dtos"
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/internal/services"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+const (
+	// CredentialHandlerName is the name of the single-credential handler.
+	CredentialHandlerName = "credential_handler" //nolint:gosec // G101 false positive: actor name, not a secret
+	// CredentialHandlerPoolName is the name of the single-credential handler pool.
+	CredentialHandlerPoolName = "credential_handler_pool" //nolint:gosec // G101 false positive: pool name, not a secret
+)
+
+type (
+	// CredentialHandlerFactory is the factory for the single-credential handler.
+	CredentialHandlerFactory HandlerFactory[*CredentialHandler]
+
+	// CredentialHandler handles a single credential resource.
+	CredentialHandler struct {
+		Handler
+		credentialService  services.CredentialService
+		defaultEnvironment string
+	}
+)
+
+// NewCredentialHandler creates a new single-credential handler factory.
+func NewCredentialHandler(credentialService services.CredentialService, cfg *config.Config) *CredentialHandlerFactory {
+	return &CredentialHandlerFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &CredentialHandler{
+				credentialService:  credentialService,
+				defaultEnvironment: cfg.Environment,
+			}
+		},
+	}
+}
+
+// environmentParam returns the ?environment= query value or the engine default.
+func (h *CredentialHandler) environmentParam(r *http.Request) string {
+	if env := r.URL.Query().Get("environment"); env != "" {
+		return env
+	}
+	return h.defaultEnvironment
+}
+
+// HandleGet retrieves a single credential's metadata (GET /v1/credentials/{id})
+// @Summary Get credential by id
+// @Description Retrieve a credential's metadata (field values are never returned)
+// @Tags credentials
+// @Accept json
+// @Produce json
+// @Param id path string true "Credential id"
+// @Success 200 {object} dtos.CredentialDTO
+// @Failure 404 {object} dtos.NotFoundError
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/credentials/{id} [get]
+func (h *CredentialHandler) HandleGet(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received get credential request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	id, err := h.GetPathParam(r, "id")
+	if err != nil {
+		return h.SendBadRequest(w, err, []string{"id is required"})
+	}
+
+	cred, err := h.credentialService.FindByID(id)
+	if err != nil {
+		if errors.Is(err, repositories.ErrCredentialNotFound) {
+			return h.SendNotFound(w, fmt.Sprintf("credential %s not found", id), []string{"id"})
+		}
+		return h.SendInternalError(w, err)
+	}
+
+	return h.SendJSON(w, http.StatusOK, dtos.ToCredentialDTO(cred))
+}
+
+// HandlePut creates or updates a credential and its field values for an environment.
+// @Summary Create or update credential
+// @Description Upsert a credential; field values are stored in the SecretStore for the target environment (?environment=)
+// @Tags credentials
+// @Accept json
+// @Produce json
+// @Param id path string true "Credential id"
+// @Param environment query string false "Environment scope for the field values (defaults to FUSE_ENVIRONMENT)"
+// @Param credential body dtos.UpsertCredentialRequest true "Credential data"
+// @Success 200 {object} dtos.UpsertCredentialResponse
+// @Failure 400 {object} dtos.BadRequestError
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/credentials/{id} [put]
+func (h *CredentialHandler) HandlePut(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received upsert credential request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	id, err := h.GetPathParam(r, "id")
+	if err != nil {
+		return h.SendBadRequest(w, err, []string{"id is required"})
+	}
+
+	var req dtos.UpsertCredentialRequest
+	if bindErr := h.BindJSON(w, r, &req); bindErr != nil {
+		return h.SendBadRequest(w, bindErr, []string{"body"})
+	}
+
+	cred := workflow.NewCredential(id, req.Type, req.Description, nil)
+	if _, saveErr := h.credentialService.Save(cred, req.Fields, h.environmentParam(r)); saveErr != nil {
+		if errors.Is(saveErr, services.ErrReadOnlySecretStore) {
+			return h.SendBadRequest(w, saveErr, []string{"SECRETS_DRIVER"})
+		}
+		// Validation errors (id/type/field format) are client errors.
+		if cred.Validate() != nil {
+			return h.SendBadRequest(w, saveErr, []string{"credential"})
+		}
+		return h.SendInternalError(w, saveErr)
+	}
+
+	return h.SendJSON(w, http.StatusOK, dtos.UpsertCredentialResponse{
+		Message:    "Credential saved successfully",
+		Credential: id,
+	})
+}
+
+// HandleDelete removes a credential and its field values for an environment.
+// @Summary Delete credential
+// @Description Delete a credential's metadata and its field values for the target environment (?environment=)
+// @Tags credentials
+// @Accept json
+// @Produce json
+// @Param id path string true "Credential id"
+// @Param environment query string false "Environment scope for the field values (defaults to FUSE_ENVIRONMENT)"
+// @Success 204 "No Content"
+// @Failure 404 {object} dtos.NotFoundError
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/credentials/{id} [delete]
+func (h *CredentialHandler) HandleDelete(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received delete credential request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	id, err := h.GetPathParam(r, "id")
+	if err != nil {
+		return h.SendBadRequest(w, err, []string{"id is required"})
+	}
+
+	if delErr := h.credentialService.Delete(id, h.environmentParam(r)); delErr != nil {
+		if errors.Is(delErr, repositories.ErrCredentialNotFound) {
+			return h.SendNotFound(w, fmt.Sprintf("credential %s not found", id), []string{"id"})
+		}
+		return h.SendInternalError(w, delErr)
+	}
+
+	return h.SendJSON(w, http.StatusNoContent, nil)
+}

--- a/internal/handlers/credentials.go
+++ b/internal/handlers/credentials.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"net/http"
+
+	"ergo.services/ergo/gen"
+	"github.com/open-source-cloud/fuse/internal/dtos"
+	"github.com/open-source-cloud/fuse/internal/services"
+)
+
+const (
+	// CredentialsHandlerName is the name of the credentials list handler.
+	CredentialsHandlerName = "credentials_handler"
+	// CredentialsHandlerPoolName is the name of the credentials list handler pool.
+	CredentialsHandlerPoolName = "credentials_handler_pool"
+)
+
+type (
+	// CredentialsHandlerFactory is the factory for the credentials list handler.
+	CredentialsHandlerFactory HandlerFactory[*CredentialsHandler]
+
+	// CredentialsHandler handles the credentials collection endpoint.
+	CredentialsHandler struct {
+		Handler
+		credentialService services.CredentialService
+	}
+)
+
+// NewCredentialsHandler creates a new credentials list handler factory.
+func NewCredentialsHandler(credentialService services.CredentialService) *CredentialsHandlerFactory {
+	return &CredentialsHandlerFactory{
+		Factory: func() gen.ProcessBehavior {
+			return &CredentialsHandler{credentialService: credentialService}
+		},
+	}
+}
+
+// HandleGet lists all credentials, metadata only (GET /v1/credentials)
+// @Summary List credentials
+// @Description Retrieve all credentials (metadata only; field values are never returned)
+// @Tags credentials
+// @Accept json
+// @Produce json
+// @Success 200 {object} dtos.CredentialListResponse
+// @Failure 500 {object} dtos.InternalServerErrorResponse
+// @Router /v1/credentials [get]
+func (h *CredentialsHandler) HandleGet(from gen.PID, w http.ResponseWriter, r *http.Request) error {
+	h.Log().Info("received list credentials request from: %v remoteAddr: %s", from, r.RemoteAddr)
+
+	creds, err := h.credentialService.FindAll()
+	if err != nil {
+		return h.SendInternalError(w, err)
+	}
+
+	items := make([]dtos.CredentialDTO, len(creds))
+	for i, c := range creds {
+		items[i] = dtos.ToCredentialDTO(c)
+	}
+
+	return h.SendJSON(w, http.StatusOK, dtos.CredentialListResponse{Items: items})
+}

--- a/internal/repositories/credential.go
+++ b/internal/repositories/credential.go
@@ -1,0 +1,21 @@
+package repositories
+
+import (
+	"errors"
+
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+// ErrCredentialNotFound is returned when a credential is not found.
+var ErrCredentialNotFound = errors.New("credential not found")
+
+type (
+	// CredentialRepository stores credential metadata (ADR-0031 Option B). Field VALUES are not
+	// stored here; they live in the SecretStore at cred/<id>/<field>, per environment.
+	CredentialRepository interface {
+		FindByID(id string) (*workflow.Credential, error)
+		FindAll() ([]*workflow.Credential, error)
+		Save(cred *workflow.Credential) error
+		Delete(id string) error
+	}
+)

--- a/internal/repositories/credential_memory.go
+++ b/internal/repositories/credential_memory.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+// MemoryCredentialRepository is an in-memory CredentialRepository for dev and testing.
+type MemoryCredentialRepository struct {
+	mu          sync.RWMutex
+	credentials map[string]*workflow.Credential
+}
+
+// NewMemoryCredentialRepository creates an empty memory credential repository.
+func NewMemoryCredentialRepository() *MemoryCredentialRepository {
+	return &MemoryCredentialRepository{credentials: make(map[string]*workflow.Credential)}
+}
+
+// FindByID finds a credential by id.
+func (r *MemoryCredentialRepository) FindByID(id string) (*workflow.Credential, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	cred, ok := r.credentials[id]
+	if !ok {
+		return nil, ErrCredentialNotFound
+	}
+	return cred, nil
+}
+
+// FindAll returns all credentials sorted by id.
+func (r *MemoryCredentialRepository) FindAll() ([]*workflow.Credential, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	creds := make([]*workflow.Credential, 0, len(r.credentials))
+	for _, cred := range r.credentials {
+		creds = append(creds, cred)
+	}
+	sort.Slice(creds, func(i, j int) bool { return creds[i].ID < creds[j].ID })
+	return creds, nil
+}
+
+// Save upserts a credential.
+func (r *MemoryCredentialRepository) Save(cred *workflow.Credential) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.credentials[cred.ID] = cred
+	return nil
+}
+
+// Delete removes a credential by id.
+func (r *MemoryCredentialRepository) Delete(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.credentials, id)
+	return nil
+}

--- a/internal/repositories/credential_memory_test.go
+++ b/internal/repositories/credential_memory_test.go
@@ -1,0 +1,55 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryCredentialRepository(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Save and FindByID round-trip", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryCredentialRepository()
+
+		require.NoError(t, repo.Save(workflow.NewCredential("openai-prod", "openai", "Prod", []string{"apiKey"})))
+		cred, err := repo.FindByID("openai-prod")
+
+		require.NoError(t, err)
+		assert.Equal(t, "openai", cred.Type)
+		assert.Equal(t, []string{"apiKey"}, cred.Fields)
+	})
+
+	t.Run("FindByID returns ErrCredentialNotFound for unknown", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryCredentialRepository()
+		_, err := repo.FindByID("nope")
+		assert.ErrorIs(t, err, ErrCredentialNotFound)
+	})
+
+	t.Run("FindAll returns sorted credentials", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryCredentialRepository()
+		require.NoError(t, repo.Save(workflow.NewCredential("b-cred", "custom", "", nil)))
+		require.NoError(t, repo.Save(workflow.NewCredential("a-cred", "custom", "", nil)))
+
+		creds, err := repo.FindAll()
+		require.NoError(t, err)
+		require.Len(t, creds, 2)
+		assert.Equal(t, "a-cred", creds[0].ID)
+		assert.Equal(t, "b-cred", creds[1].ID)
+	})
+
+	t.Run("Delete removes a credential", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMemoryCredentialRepository()
+		require.NoError(t, repo.Save(workflow.NewCredential("c1", "custom", "", nil)))
+
+		require.NoError(t, repo.Delete("c1"))
+		_, err := repo.FindByID("c1")
+		assert.ErrorIs(t, err, ErrCredentialNotFound)
+	})
+}

--- a/internal/repositories/postgres/credential.go
+++ b/internal/repositories/postgres/credential.go
@@ -1,0 +1,93 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+// CredentialRepository is a PostgreSQL-backed CredentialRepository (ADR-0031 Option B). It stores
+// only credential metadata; field values live in the secrets table at cred/<id>/<field>.
+type CredentialRepository struct {
+	pool *pgxpool.Pool
+}
+
+// compile-time assertion.
+var _ repositories.CredentialRepository = (*CredentialRepository)(nil)
+
+// NewCredentialRepository creates a new PostgreSQL-backed CredentialRepository.
+func NewCredentialRepository(pool *pgxpool.Pool) repositories.CredentialRepository {
+	return &CredentialRepository{pool: pool}
+}
+
+// FindByID retrieves a credential by id.
+func (r *CredentialRepository) FindByID(id string) (*workflow.Credential, error) {
+	ctx := context.Background()
+
+	var credType, description string
+	var fields []string
+	err := r.pool.QueryRow(ctx,
+		`SELECT type, description, fields FROM credentials WHERE id = $1`, id,
+	).Scan(&credType, &description, &fields)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, repositories.ErrCredentialNotFound
+		}
+		return nil, fmt.Errorf("postgres/credential: find by id: %w", err)
+	}
+	return workflow.NewCredential(id, credType, description, fields), nil
+}
+
+// FindAll retrieves all credentials sorted by id.
+func (r *CredentialRepository) FindAll() ([]*workflow.Credential, error) {
+	ctx := context.Background()
+
+	rows, err := r.pool.Query(ctx, `SELECT id, type, description, fields FROM credentials ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("postgres/credential: find all: %w", err)
+	}
+	defer rows.Close()
+
+	creds := make([]*workflow.Credential, 0)
+	for rows.Next() {
+		var id, credType, description string
+		var fields []string
+		if err := rows.Scan(&id, &credType, &description, &fields); err != nil {
+			return nil, fmt.Errorf("postgres/credential: scan row: %w", err)
+		}
+		creds = append(creds, workflow.NewCredential(id, credType, description, fields))
+	}
+	return creds, rows.Err()
+}
+
+// Save upserts a credential's metadata.
+func (r *CredentialRepository) Save(cred *workflow.Credential) error {
+	ctx := context.Background()
+
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO credentials (id, type, description, fields, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, NOW(), NOW())
+		ON CONFLICT (id) DO UPDATE SET
+			type = EXCLUDED.type,
+			description = EXCLUDED.description,
+			fields = EXCLUDED.fields,
+			updated_at = NOW()
+	`, cred.ID, cred.Type, cred.Description, cred.Fields)
+	if err != nil {
+		return fmt.Errorf("postgres/credential: upsert %q: %w", cred.ID, err)
+	}
+	return nil
+}
+
+// Delete removes a credential's metadata by id.
+func (r *CredentialRepository) Delete(id string) error {
+	ctx := context.Background()
+	if _, err := r.pool.Exec(ctx, `DELETE FROM credentials WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("postgres/credential: delete %q: %w", id, err)
+	}
+	return nil
+}

--- a/internal/repositories/postgres/migrations/000011_create_credentials.down.sql
+++ b/internal/repositories/postgres/migrations/000011_create_credentials.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS credentials;

--- a/internal/repositories/postgres/migrations/000011_create_credentials.up.sql
+++ b/internal/repositories/postgres/migrations/000011_create_credentials.up.sql
@@ -1,0 +1,14 @@
+-- ADR-0031 Phase 2 (Option B): typed, centrally-managed credential metadata.
+-- Field VALUES are NOT stored here; they live in the secrets table at name
+-- cred/<id>/<field>, per environment (reusing the encrypted secret store).
+-- NOTE: numbered 000011 to follow the environments table (000010); this migration
+-- must be applied after that one when both land on main.
+
+CREATE TABLE credentials (
+    id          VARCHAR(128) PRIMARY KEY,
+    type        VARCHAR(128) NOT NULL,
+    description VARCHAR(512) NOT NULL DEFAULT '',
+    fields      TEXT[]       NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);

--- a/internal/services/credential_service.go
+++ b/internal/services/credential_service.go
@@ -1,0 +1,127 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+)
+
+// ErrReadOnlySecretStore is returned when credential values are written against a read-only
+// secret backend. Credential management requires a ManagedSecretStore (memory or postgres).
+var ErrReadOnlySecretStore = errors.New("the configured SECRETS_DRIVER is read-only; credential values require driver=memory or driver=postgres")
+
+type (
+	// CredentialService manages credential metadata and their per-environment field values
+	// (ADR-0031 Option B). Metadata lives in the CredentialRepository; values live in the
+	// SecretStore at cred/<id>/<field>. Values are never returned by reads.
+	CredentialService interface {
+		FindAll() ([]*workflow.Credential, error)
+		FindByID(id string) (*workflow.Credential, error)
+		Save(cred *workflow.Credential, fieldValues map[string]string, environment string) (*workflow.Credential, error)
+		Delete(id string, environment string) error
+		Resolve(ctx context.Context, environment, id, field string) (secrets.SecretValue, error)
+	}
+
+	// DefaultCredentialService is the default CredentialService implementation.
+	DefaultCredentialService struct {
+		repo  repositories.CredentialRepository
+		store secrets.SecretStore
+	}
+)
+
+// NewCredentialService returns a new CredentialService.
+func NewCredentialService(repo repositories.CredentialRepository, store secrets.SecretStore) CredentialService {
+	return &DefaultCredentialService{repo: repo, store: store}
+}
+
+// FindAll returns all credential metadata (never values).
+func (s *DefaultCredentialService) FindAll() ([]*workflow.Credential, error) {
+	return s.repo.FindAll()
+}
+
+// FindByID returns a single credential's metadata (never values).
+func (s *DefaultCredentialService) FindByID(id string) (*workflow.Credential, error) {
+	return s.repo.FindByID(id)
+}
+
+// Save validates and persists the credential metadata, then writes each field value to the
+// SecretStore at cred/<id>/<field> in the given environment. The credential's Fields are the
+// union of any previously-recorded field names and the provided value keys, so metadata tracks
+// every field that has a value (and incremental single-field updates don't drop others).
+func (s *DefaultCredentialService) Save(cred *workflow.Credential, fieldValues map[string]string, environment string) (*workflow.Credential, error) {
+	existing := make([]string, 0)
+	if prev, err := s.repo.FindByID(cred.ID); err == nil {
+		existing = prev.Fields
+	}
+	cred.Fields = unionSorted(existing, keys(fieldValues))
+	if err := cred.Validate(); err != nil {
+		return nil, err
+	}
+
+	managed, ok := s.store.(secrets.ManagedSecretStore)
+	if !ok {
+		return nil, ErrReadOnlySecretStore
+	}
+
+	if err := s.repo.Save(cred); err != nil {
+		return nil, err
+	}
+
+	for field, value := range fieldValues {
+		if err := managed.Set(context.Background(), secrets.Scope{Environment: environment}, secrets.CredentialSecretName(cred.ID, field), value); err != nil {
+			return nil, err
+		}
+	}
+	return cred, nil
+}
+
+// Delete removes the credential's field secrets in the given environment, then its metadata.
+func (s *DefaultCredentialService) Delete(id string, environment string) error {
+	cred, err := s.repo.FindByID(id)
+	if err != nil {
+		return err
+	}
+
+	if managed, ok := s.store.(secrets.ManagedSecretStore); ok {
+		for _, field := range cred.Fields {
+			if delErr := managed.Delete(context.Background(), secrets.Scope{Environment: environment}, secrets.CredentialSecretName(id, field)); delErr != nil {
+				return delErr
+			}
+		}
+	}
+	return s.repo.Delete(id)
+}
+
+// Resolve returns a credential field's value for an environment as a redacted SecretValue.
+func (s *DefaultCredentialService) Resolve(ctx context.Context, environment, id, field string) (secrets.SecretValue, error) {
+	return s.store.Resolve(ctx, secrets.Scope{Environment: environment}, secrets.CredentialSecretName(id, field))
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// unionSorted returns the sorted, de-duplicated union of two field-name slices.
+func unionSorted(a, b []string) []string {
+	set := make(map[string]struct{}, len(a)+len(b))
+	for _, v := range a {
+		set[v] = struct{}{}
+	}
+	for _, v := range b {
+		set[v] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/services/credential_service_test.go
+++ b/internal/services/credential_service_test.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readOnlyStore implements secrets.SecretStore but NOT secrets.ManagedSecretStore.
+type readOnlyStore struct{}
+
+func (readOnlyStore) Resolve(_ context.Context, _ secrets.Scope, _ string) (secrets.SecretValue, error) {
+	return secrets.SecretValue{}, secrets.ErrSecretNotFound
+}
+
+func newCredentialService() (CredentialService, secrets.SecretStore) {
+	store := secrets.NewMemorySecretStore()
+	return NewCredentialService(repositories.NewMemoryCredentialRepository(), store), store
+}
+
+func TestCredentialService_SaveWritesValuesToSecretStore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, store := newCredentialService()
+
+	_, err := svc.Save(workflow.NewCredential("openai-prod", "openai", "Prod", nil),
+		map[string]string{"apiKey": "sk-staging"}, "staging")
+	require.NoError(t, err)
+
+	// Value is stored at the reserved name in the right environment.
+	got, err := store.Resolve(ctx, secrets.Scope{Environment: "staging"}, secrets.CredentialSecretName("openai-prod", "apiKey"))
+	require.NoError(t, err)
+	assert.Equal(t, "sk-staging", got.Reveal())
+
+	// Per-environment isolation: not visible in another environment.
+	_, err = store.Resolve(ctx, secrets.Scope{Environment: "default"}, secrets.CredentialSecretName("openai-prod", "apiKey"))
+	assert.ErrorIs(t, err, secrets.ErrSecretNotFound)
+
+	// Metadata records the field name; never the value.
+	cred, err := svc.FindByID("openai-prod")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"apiKey"}, cred.Fields)
+}
+
+func TestCredentialService_SaveMergesFields(t *testing.T) {
+	t.Parallel()
+	svc, _ := newCredentialService()
+
+	_, err := svc.Save(workflow.NewCredential("c1", "custom", "", nil), map[string]string{"apiKey": "a"}, "default")
+	require.NoError(t, err)
+	_, err = svc.Save(workflow.NewCredential("c1", "custom", "", nil), map[string]string{"baseUrl": "b"}, "default")
+	require.NoError(t, err)
+
+	cred, err := svc.FindByID("c1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"apiKey", "baseUrl"}, cred.Fields)
+}
+
+func TestCredentialService_SaveReadOnlyStoreErrors(t *testing.T) {
+	t.Parallel()
+	svc := NewCredentialService(repositories.NewMemoryCredentialRepository(), readOnlyStore{})
+
+	_, err := svc.Save(workflow.NewCredential("c1", "custom", "", nil), map[string]string{"k": "v"}, "default")
+	assert.ErrorIs(t, err, ErrReadOnlySecretStore)
+}
+
+func TestCredentialService_DeleteRemovesValues(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc, store := newCredentialService()
+	_, err := svc.Save(workflow.NewCredential("c1", "custom", "", nil), map[string]string{"apiKey": "a"}, "staging")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Delete("c1", "staging"))
+
+	_, err = svc.FindByID("c1")
+	assert.ErrorIs(t, err, repositories.ErrCredentialNotFound)
+	_, err = store.Resolve(ctx, secrets.Scope{Environment: "staging"}, secrets.CredentialSecretName("c1", "apiKey"))
+	assert.ErrorIs(t, err, secrets.ErrSecretNotFound)
+}
+
+func TestCredentialService_Resolve(t *testing.T) {
+	t.Parallel()
+	svc, _ := newCredentialService()
+	_, err := svc.Save(workflow.NewCredential("c1", "custom", "", nil), map[string]string{"apiKey": "a"}, "default")
+	require.NoError(t, err)
+
+	v, err := svc.Resolve(context.Background(), "default", "c1", "apiKey")
+	require.NoError(t, err)
+	assert.Equal(t, "a", v.Reveal())
+}

--- a/pkg/secrets/credential.go
+++ b/pkg/secrets/credential.go
@@ -1,0 +1,70 @@
+package secrets
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// credentialSecretPrefix namespaces credential field values within the SecretStore. A credential
+// field is stored as the secret named "cred/<id>/<field>" (ADR-0031 Option B). The "/" separator
+// is deliberately outside the {{secret:NAME}} charset so a secret reference can never address a
+// credential value and the two namespaces cannot collide.
+const credentialSecretPrefix = "cred"
+
+// CredentialSecretName maps a credential field to its reserved SecretStore name.
+func CredentialSecretName(id, field string) string {
+	return fmt.Sprintf("%s/%s/%s", credentialSecretPrefix, id, field)
+}
+
+// credentialRefPattern matches {{credential:ID.FIELD}} tokens. ID may contain dots; FIELD may not,
+// so the value is split on the LAST dot (ID captured greedily, FIELD as the trailing segment).
+var credentialRefPattern = regexp.MustCompile(`\{\{credential:([A-Za-z0-9_.\-]+)\.([A-Za-z0-9_\-]+)\}\}`)
+
+// CredentialRefToken renders the {{credential:ID.FIELD}} token form.
+func CredentialRefToken(id, field string) string {
+	return fmt.Sprintf("{{credential:%s.%s}}", id, field)
+}
+
+// HasCredentialRef reports whether s contains any {{credential:ID.FIELD}} token.
+func HasCredentialRef(s string) bool {
+	return credentialRefPattern.MatchString(s)
+}
+
+// CredentialRefs returns the distinct (id, field) pairs referenced in s.
+func CredentialRefs(s string) [][2]string {
+	matches := credentialRefPattern.FindAllStringSubmatch(s, -1)
+	refs := make([][2]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		key := m[1] + "/" + m[2]
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, [2]string{m[1], m[2]})
+	}
+	return refs
+}
+
+// ReplaceCredentialRefs replaces each {{credential:ID.FIELD}} in s with resolve(secretName), where
+// secretName is the reserved CredentialSecretName(ID, FIELD); it returns the first resolution
+// error if any. The resolved plaintext must be wrapped in a SecretValue by the caller.
+func ReplaceCredentialRefs(s string, resolve func(secretName string) (string, error)) (string, error) {
+	var firstErr error
+	out := credentialRefPattern.ReplaceAllStringFunc(s, func(token string) string {
+		if firstErr != nil {
+			return token
+		}
+		m := credentialRefPattern.FindStringSubmatch(token)
+		val, err := resolve(CredentialSecretName(m[1], m[2]))
+		if err != nil {
+			firstErr = err
+			return token
+		}
+		return val
+	})
+	if firstErr != nil {
+		return "", firstErr
+	}
+	return out, nil
+}

--- a/pkg/secrets/credential_test.go
+++ b/pkg/secrets/credential_test.go
@@ -1,0 +1,53 @@
+package secrets_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/open-source-cloud/fuse/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialSecretName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "cred/openai-prod/apiKey", secrets.CredentialSecretName("openai-prod", "apiKey"))
+}
+
+func TestCredentialRefs(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, secrets.HasCredentialRef("Bearer {{credential:openai-prod.apiKey}}"))
+	assert.False(t, secrets.HasCredentialRef("no refs"))
+	assert.False(t, secrets.HasCredentialRef("{{secret:plain}}"))
+
+	// ID may contain dots; field is the trailing segment (split on the last dot).
+	refs := secrets.CredentialRefs("{{credential:my.org.openai.apiKey}} {{credential:my.org.openai.apiKey}}")
+	require.Len(t, refs, 1)
+	assert.Equal(t, [2]string{"my.org.openai", "apiKey"}, refs[0])
+}
+
+func TestReplaceCredentialRefs(t *testing.T) {
+	t.Parallel()
+
+	out, err := secrets.ReplaceCredentialRefs("Bearer {{credential:openai-prod.apiKey}}!", func(secretName string) (string, error) {
+		assert.Equal(t, "cred/openai-prod/apiKey", secretName)
+		return "sk-xyz", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer sk-xyz!", out)
+
+	_, err = secrets.ReplaceCredentialRefs("{{credential:x.y}}", func(string) (string, error) {
+		return "", errors.New("boom")
+	})
+	require.Error(t, err)
+}
+
+// TestCredentialNamespaceDoesNotCollideWithSecretRefs guards the load-bearing invariant: the
+// "/" separator in a credential's reserved secret name is outside the {{secret:NAME}} charset, so
+// a secret reference can never address a credential value.
+func TestCredentialNamespaceDoesNotCollideWithSecretRefs(t *testing.T) {
+	t.Parallel()
+	name := secrets.CredentialSecretName("openai-prod", "apiKey")
+	assert.False(t, secrets.HasSecretRef("{{secret:"+name+"}}"))
+}

--- a/pkg/workflow/credential.go
+++ b/pkg/workflow/credential.go
@@ -1,0 +1,49 @@
+package workflow
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// credentialIDPattern restricts credential ids to lowercase alphanumerics plus -._ so they are
+// safe URL path segments. The absence of "/" keeps the reserved cred/<id>/<field> secret name
+// from colliding with the {{secret:NAME}} namespace (ADR-0031).
+var credentialIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_.\-]*$`)
+
+// credentialFieldPattern restricts field names to mixed-case alphanumerics plus -_ (no dot, which
+// separates id from field in the {{credential:id.field}} token). camelCase like "apiKey" is allowed.
+var credentialFieldPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_\-]*$`)
+
+// Credential is typed, centrally-managed credential metadata (ADR-0031 Option B). Field VALUES are
+// NOT stored here: they live in the SecretStore at cred/<id>/<field>, per environment. This struct
+// only carries the field NAMES so the value plaintext never flows through metadata sinks.
+type Credential struct {
+	ID          string   `json:"id" validate:"required"`
+	Type        string   `json:"type" validate:"required"`
+	Description string   `json:"description,omitempty"`
+	Fields      []string `json:"fields"`
+}
+
+// NewCredential creates a Credential from metadata (field names only).
+func NewCredential(id, credType, description string, fields []string) *Credential {
+	return &Credential{ID: id, Type: credType, Description: description, Fields: fields}
+}
+
+// Validate checks the credential's required fields and the id / field-name format.
+func (c *Credential) Validate() error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.Struct(c); err != nil {
+		return err
+	}
+	if !credentialIDPattern.MatchString(c.ID) {
+		return fmt.Errorf("invalid credential id %q: must match %s", c.ID, credentialIDPattern.String())
+	}
+	for _, f := range c.Fields {
+		if !credentialFieldPattern.MatchString(f) {
+			return fmt.Errorf("invalid credential field name %q: must match %s", f, credentialFieldPattern.String())
+		}
+	}
+	return nil
+}

--- a/pkg/workflow/credential_test.go
+++ b/pkg/workflow/credential_test.go
@@ -1,0 +1,38 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cred    *Credential
+		wantErr bool
+	}{
+		{name: "valid", cred: NewCredential("openai-prod", "openai", "Prod key", []string{"apiKey"}), wantErr: false},
+		{name: "dotted id ok", cred: NewCredential("my.org.openai", "openai", "", []string{"apiKey", "baseUrl"}), wantErr: false},
+		{name: "no fields ok", cred: NewCredential("empty", "custom", "", nil), wantErr: false},
+		{name: "missing id", cred: NewCredential("", "openai", "", []string{"apiKey"}), wantErr: true},
+		{name: "missing type", cred: NewCredential("c1", "", "", []string{"apiKey"}), wantErr: true},
+		{name: "uppercase id rejected", cred: NewCredential("Prod", "openai", "", nil), wantErr: true},
+		{name: "bad field name rejected", cred: NewCredential("c1", "openai", "", []string{"api Key"}), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cred.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/tests/functional/credential_repository_test.go
+++ b/tests/functional/credential_repository_test.go
@@ -1,0 +1,78 @@
+package functional_test
+
+import (
+	"testing"
+
+	"github.com/open-source-cloud/fuse/internal/repositories"
+	"github.com/open-source-cloud/fuse/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func contractTestCredentialRepository(t *testing.T, newRepo func() repositories.CredentialRepository, reset func()) {
+	t.Helper()
+
+	t.Run("Save and FindByID returns same credential incl. fields array", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+
+		require.NoError(t, repo.Save(workflow.NewCredential("openai-prod", "openai", "Prod creds", []string{"apiKey", "baseUrl"})))
+		found, err := repo.FindByID("openai-prod")
+
+		require.NoError(t, err)
+		assert.Equal(t, "openai", found.Type)
+		assert.Equal(t, "Prod creds", found.Description)
+		assert.Equal(t, []string{"apiKey", "baseUrl"}, found.Fields)
+	})
+
+	t.Run("FindByID returns ErrCredentialNotFound for unknown", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		_, err := repo.FindByID("nonexistent")
+		assert.ErrorIs(t, err, repositories.ErrCredentialNotFound)
+	})
+
+	t.Run("FindAll returns saved credentials", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		require.NoError(t, repo.Save(workflow.NewCredential("a-cred", "custom", "", []string{"token"})))
+		require.NoError(t, repo.Save(workflow.NewCredential("b-cred", "custom", "", nil)))
+
+		all, err := repo.FindAll()
+		require.NoError(t, err)
+		ids := make([]string, len(all))
+		for i, c := range all {
+			ids[i] = c.ID
+		}
+		assert.Contains(t, ids, "a-cred")
+		assert.Contains(t, ids, "b-cred")
+	})
+
+	t.Run("Save overwrites metadata", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		require.NoError(t, repo.Save(workflow.NewCredential("c1", "openai", "old", []string{"apiKey"})))
+		require.NoError(t, repo.Save(workflow.NewCredential("c1", "openai", "new", []string{"apiKey", "baseUrl"})))
+
+		found, err := repo.FindByID("c1")
+		require.NoError(t, err)
+		assert.Equal(t, "new", found.Description)
+		assert.Equal(t, []string{"apiKey", "baseUrl"}, found.Fields)
+	})
+
+	t.Run("Delete removes credential", func(t *testing.T) {
+		reset()
+		repo := newRepo()
+		require.NoError(t, repo.Save(workflow.NewCredential("c1", "custom", "", nil)))
+
+		require.NoError(t, repo.Delete("c1"))
+		_, err := repo.FindByID("c1")
+		assert.ErrorIs(t, err, repositories.ErrCredentialNotFound)
+	})
+}
+
+func TestMemoryCredentialRepository_Contract(t *testing.T) {
+	contractTestCredentialRepository(t, func() repositories.CredentialRepository {
+		return repositories.NewMemoryCredentialRepository()
+	}, func() {})
+}

--- a/tests/functional/postgres_test.go
+++ b/tests/functional/postgres_test.go
@@ -182,6 +182,18 @@ func TestPostgresPackageRepository_Contract(t *testing.T) {
 	})
 }
 
+// --- Postgres Credential Repository ---
+
+func TestPostgresCredentialRepository_Contract(t *testing.T) {
+	pool := setupTestPool(t)
+	contractTestCredentialRepository(t, func() repositories.CredentialRepository {
+		return postgres.NewCredentialRepository(pool)
+	}, func() {
+		_, err := pool.Exec(context.Background(), "TRUNCATE TABLE credentials")
+		require.NoError(t, err)
+	})
+}
+
 // --- Postgres Claim Repository ---
 
 func TestPostgresClaimRepository_Contract(t *testing.T) {


### PR DESCRIPTION
## What & why

ADR-0031 Phase 2 / Option B, **deliverable 3 of 4 — PR 1 (registry/management layer)**. Stacked on
**PR #85** (`feat/per-context-llm-keys`), which it needs for the consumption PR's LLM-by-credential
wiring; this PR has no engine changes.

> Base is #85 so the diff is scoped. Retarget to `main` after #85 merges.
> **Migration `000011` must land after the environments migration `000010` (PR #84).**

Typed, centrally-managed **credential objects** ("OpenAI prod") referenced by id. A credential is
**metadata** (id, free-form `type`, description, field names); its field **values live in the
existing SecretStore at the reserved name `cred/<id>/<field>`, per environment** — one custody
point, reusing Phase-1 encryption + scoping.

## Changes (registry only — consumption wiring is a follow-up PR)
- **`pkg/workflow/credential.go`** — `Credential` domain + validation (lowercase id; mixed-case,
  dot-free field names like `apiKey`).
- **`pkg/secrets/credential.go`** — `CredentialSecretName` + `{{credential:id.field}}` token
  helpers. The `/` separator is outside the `{{secret:NAME}}` charset, so credential values can
  **never collide** with secret refs (asserted by a test).
- **Repository** — `CredentialRepository` (memory + Postgres `TEXT[]` fields) + migration `000011`.
- **`CredentialService`** — writes values to the SecretStore via `ManagedSecretStore` per
  environment (read-only backends → `ErrReadOnlySecretStore`); `Fields` merged across saves; reads
  return **metadata only, never values**.
- **CRUD API** — `GET /v1/credentials`, `GET/PUT/DELETE /v1/credentials/{id}` (`?environment=`
  selects the value scope; GET never returns values).
- **CLI** — `fuse credentials set/list/delete`.

## Tests
`make lint` clean, `make build` ok, `make test` **670 passing**, `make swagger` regenerates cleanly.
Domain/helper/namespace-collision tests, memory repo, service (value→store, per-env isolation,
read-only fallback, field merge), and a memory+postgres functional contract test.

## Follow-up (PR 2)
Consumption wiring: input-mapping `source:"credential"`, the `{{credential:id.field}}` token in
schema values, and `LLM_<PROVIDER>_CREDENTIAL=<id>` — all resolving through the existing
environment-scoped secret resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)